### PR TITLE
Gas price estimation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -110,6 +110,7 @@ searcher_command = (
     + "--private-key $SEARCHER_SK "
     + "--chain-id development "
     + "--verbose "
+    + "--bid 10000000000000000 "
     + "--liquidation-server-url http://localhost:9000"
 )
 local_resource(

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -46,7 +46,10 @@ use {
         Router,
     },
     clap::crate_version,
-    ethers::types::Bytes,
+    ethers::types::{
+        Bytes,
+        U256,
+    },
     serde::{
         Deserialize,
         Serialize,
@@ -86,6 +89,11 @@ pub enum RestError {
     OpportunityNotFound,
     /// The bid was not found
     BidNotFound,
+    /// The gas cost of executing the call exceeded the total value of all paid bids
+    ExcessiveGasCost {
+        gas_cost:         U256,
+        total_bid_amount: U256,
+    },
     /// Internal error occurred during processing the request
     TemporarilyUnavailable,
 }
@@ -115,6 +123,10 @@ impl RestError {
             RestError::BidNotFound => (
                 StatusCode::NOT_FOUND,
                 "Bid with the specified id was not found".to_string(),
+            ),
+            RestError::ExcessiveGasCost { gas_cost, total_bid_amount } => (
+                StatusCode::BAD_REQUEST,
+                format!("The gas cost of executing the call ({}) exceeded the total value of all paid bids ({})", gas_cost, total_bid_amount),
             ),
             RestError::TemporarilyUnavailable => (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/auction-server/src/auction.rs
+++ b/auction-server/src/auction.rs
@@ -184,17 +184,6 @@ pub async fn simulate_bids(
     // TODO: implement L1 data fee estimation for L2s
     // E.g. Optimism: https://docs.optimism.io/stack/transactions/fees#formula
 
-    // TODO: delete
-    // I think base fee estimation below is worse--redirect to uninterpretable eth_gasPrice rpc call whose implementation seems node-specific.
-    // The Besu client for example uses median of last 100 blocks, which is not a great estimate of current base fee relative to the last block (guaranteed to be within 12.5%)
-    // let base_fee_result = provider.get_gas_price().await;
-    // let base_fee = match base_fee_result {
-    //     Ok(price) => price,
-    //     Err(e) => {
-    //         return Err(SimulationError::ContractError(ContractError::ProviderError { e }));
-    //     }
-    // };
-
     let gas_cost = gas_estimate * max_fee;
 
     match call.await {

--- a/per_multicall/script/Vault.s.sol
+++ b/per_multicall/script/Vault.s.sol
@@ -438,7 +438,7 @@ contract VaultScript is Script {
         IERC20(address(token2)).approve(opportunityAdapter, 199_999_999);
         // deposit ETH to get WETH
         WETH9(payable(wethAddress)).deposit{value: 1 ether}();
-        WETH9(payable(wethAddress)).approve(opportunityAdapter, 399_999_999);
+        WETH9(payable(wethAddress)).approve(opportunityAdapter, 1 ether);
         vm.stopBroadcast();
         vm.startBroadcast(sksScript[1]);
         IERC20(address(token1)).approve(opportunityAdapter, 199_999_999);


### PR DESCRIPTION
- estimates the max fee necessary to land the transaction/bid on-chain
- require sum of bids to exceed the estimated gas cost
- TODO: perform gas price estimation before submission
- TODO: add L1 data fee estimation for L2s