### PR TITLE
add allowances set to 0

### DIFF
--- a/per_multicall/src/OpportunityAdapter.sol
+++ b/per_multicall/src/OpportunityAdapter.sol
@@ -158,7 +158,7 @@ abstract contract OpportunityAdapter is SigVerify {
         }
     }
 
-    function _zeroSellTokenAllowances(
+    function _revokeAllowances(
         TokenAmount[] calldata sellTokens,
         address targetContract
     ) internal {
@@ -250,6 +250,7 @@ abstract contract OpportunityAdapter is SigVerify {
             params.targetCalldata,
             params.targetCallValue
         );
+        _revokeAllowances(params.sellTokens, params.targetContract);
         _validateAndTransferBuyTokens(
             params.buyTokens,
             params.executor,
@@ -257,7 +258,6 @@ abstract contract OpportunityAdapter is SigVerify {
         );
         _settleBid(params.executor, params.bidAmount);
         _useSignature(signature);
-        _zeroSellTokenAllowances(params.sellTokens, params.targetContract);
     }
 
     // necessary to receive ETH from WETH contract using withdraw

--- a/per_multicall/test/OpportunityAdapterIntegration.t.sol
+++ b/per_multicall/test/OpportunityAdapterIntegration.t.sol
@@ -213,10 +213,11 @@ contract OpportunityAdapterIntegrationTest is
         TokenAmount[] memory buyTokens = new TokenAmount[](1);
         uint256 buyTokenAmount = 100;
         buyTokens[0] = TokenAmount(address(buyToken), buyTokenAmount);
+        // transfer less sellToken than specified to test that allowances are revoked correctly
         bytes memory targetCalldata = abi.encodeWithSelector(
             mockTarget.transferSellTokenFromSenderAndBuyTokenToSender.selector,
             address(sellToken),
-            sellTokenAmount,
+            sellTokenAmount - 1,
             address(buyToken),
             buyTokenAmount
         );

--- a/per_multicall/test/OpportunityAdapterUnit.t.sol
+++ b/per_multicall/test/OpportunityAdapterUnit.t.sol
@@ -22,9 +22,7 @@ contract OpportunityAdapterUnitTest is Test, OpportunityAdapterSignature {
         myToken = new MyToken("SellToken", "ST");
     }
 
-    function testPrepareSellTokensZeroSellTokenAllowances(
-        uint256 tokenAmount
-    ) public {
+    function testPrepareSellTokensRevokeAllowances(uint256 tokenAmount) public {
         TokenAmount[] memory sellTokens = new TokenAmount[](1);
         sellTokens[0] = TokenAmount(address(myToken), tokenAmount);
         address executor = makeAddr("executor");
@@ -44,10 +42,7 @@ contract OpportunityAdapterUnitTest is Test, OpportunityAdapterSignature {
         );
         assertEq(myToken.balanceOf(executor), 0);
 
-        opportunityAdapter.exposed_zeroSellTokenAllowances(
-            sellTokens,
-            targetContract
-        );
+        opportunityAdapter.exposed_revokeAllowances(sellTokens, targetContract);
         assertEq(
             myToken.allowance(address(opportunityAdapter), targetContract),
             0

--- a/per_multicall/test/helpers/OpportunityAdapterHarness.sol
+++ b/per_multicall/test/helpers/OpportunityAdapterHarness.sol
@@ -13,11 +13,11 @@ contract OpportunityAdapterHarness is OpportunityAdapter {
         _prepareSellTokens(sellTokens, executor, targetContract);
     }
 
-    function exposed_zeroSellTokenAllowances(
+    function exposed_revokeAllowances(
         TokenAmount[] calldata sellTokens,
         address targetContract
     ) public {
-        _zeroSellTokenAllowances(sellTokens, targetContract);
+        _revokeAllowances(sellTokens, targetContract);
     }
 
     function exposed_checkDuplicateTokens(


### PR DESCRIPTION
add some logic to set the allowances of sellTokens to 0 after executing the opportunity. This ensures that there are no lingering nonzero token allowances outside of atomic opportunity adapter transactions.