### PR TITLE
Feat: Add recover for panic on tokio tasks

### DIFF
--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -50,6 +50,7 @@ use {
         },
         time::Duration,
     },
+    tokio::time::sleep,
 };
 
 async fn recover_on_panic<F, Fut>(name: &str, f: F)
@@ -65,6 +66,7 @@ where
             Err(err) => {
                 if err.is_panic() {
                     tracing::error!("{} is panicked: {:?}", name, err);
+                    sleep(Duration::from_millis(500)).await
                 } else {
                     break;
                 }


### PR DESCRIPTION
This PR aims to rerun the tasks we are spawning inside tokio thread in case of panic.