### PR TITLE
Fix panic recovery

### DIFF
--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -63,7 +63,7 @@ where
         let res = tokio::spawn(f()).await;
         match res {
             Ok(result) => match result {
-                Ok(_) => break,
+                Ok(_) => break, // This will happen on graceful shutdown
                 Err(err) => {
                     tracing::error!("{} returned error: {:?}", name, err);
                     sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
This PR aims to handle panic and errors of tokio tasks better.
If the task panics, it'll exit.
If it returns error, it'll rerun it.