### PR TITLE
feat: remove blockhash

### DIFF
--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -378,13 +378,6 @@ pub struct OpportunityCreateV1Svm {
     /// The chain id where the opportunity will be executed.
     #[schema(example = "solana", value_type = String)]
     pub chain_id:           ChainId,
-    /// The block hash to be used for the opportunity execution
-    #[schema(example = "DUcTi3rDyS5QEmZ4BNRBejtArmDCWaPYGfN44vBJXKL5", value_type = String)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub block_hash:         Hash,
-    /// The slot where the program params were fetched from using the RPC
-    #[schema(example = 293106477, value_type = u64)]
-    pub slot:               Slot,
 
     pub sell_tokens: Vec<TokenAmountSvm>,
     pub buy_tokens:  Vec<TokenAmountSvm>,
@@ -516,13 +509,6 @@ pub struct OpportunitySvm {
     /// Creation time of the opportunity (in microseconds since the Unix epoch)
     #[schema(example = 1_700_000_000_000_000i128, value_type = i128)]
     pub creation_time:  UnixTimestampMicros,
-    /// The block hash to be used for the opportunity execution
-    #[schema(example = "DUcTi3rDyS5QEmZ4BNRBejtArmDCWaPYGfN44vBJXKL5", value_type = String)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub block_hash:     Hash,
-    /// The slot where the program params were fetched from using the RPC
-    #[schema(example = 293106477, value_type = u64)]
-    pub slot:           Slot,
 
     #[serde(flatten)]
     #[schema(inline)]

--- a/auction-server/src/opportunity/entities/opportunity_svm.rs
+++ b/auction-server/src/opportunity/entities/opportunity_svm.rs
@@ -49,9 +49,7 @@ pub struct OpportunitySvm {
 
     pub router:             Pubkey,
     pub permission_account: Pubkey,
-    pub block_hash:         Hash,
     pub program:            OpportunitySvmProgram,
-    pub slot:               Slot,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -60,9 +58,7 @@ pub struct OpportunityCreateSvm {
 
     pub router:             Pubkey,
     pub permission_account: Pubkey,
-    pub block_hash:         Hash,
     pub program:            OpportunitySvmProgram,
-    pub slot:               Slot,
 }
 
 impl Opportunity for OpportunitySvm {
@@ -77,9 +73,7 @@ impl Opportunity for OpportunitySvm {
             ),
             router:             val.router,
             permission_account: val.permission_account,
-            block_hash:         val.block_hash,
             program:            val.program,
-            slot:               val.slot,
         }
     }
 
@@ -106,8 +100,6 @@ impl Opportunity for OpportunitySvm {
             program,
             router: self.router,
             permission_account: self.permission_account,
-            block_hash: self.block_hash,
-            slot: self.slot,
         }
     }
 }
@@ -170,8 +162,6 @@ impl From<OpportunitySvm> for api::OpportunitySvm {
         api::OpportunitySvm {
             opportunity_id: val.id,
             creation_time:  val.creation_time,
-            slot:           val.slot,
-            block_hash:     val.block_hash,
             params:         api::OpportunityParamsSvm::V1(api::OpportunityParamsV1Svm {
                 program,
                 chain_id: val.chain_id.clone(),
@@ -228,9 +218,7 @@ impl TryFrom<repository::Opportunity<repository::OpportunityMetadataSvm>> for Op
             },
             router: val.metadata.router,
             permission_account: val.metadata.permission_account,
-            block_hash: val.metadata.block_hash,
             program,
-            slot: val.metadata.slot,
         })
     }
 }
@@ -270,8 +258,6 @@ impl From<api::OpportunityCreateSvm> for OpportunityCreateSvm {
             program,
             permission_account: params.permission_account,
             router: params.router,
-            block_hash: params.block_hash,
-            slot: params.slot,
         }
     }
 }
@@ -287,9 +273,7 @@ impl From<OpportunitySvm> for OpportunityCreateSvm {
             },
             router:             val.router,
             permission_account: val.permission_account,
-            block_hash:         val.block_hash,
             program:            val.program,
-            slot:               val.slot,
         }
     }
 }

--- a/auction-server/src/opportunity/repository/models.rs
+++ b/auction-server/src/opportunity/repository/models.rs
@@ -79,9 +79,6 @@ pub struct OpportunityMetadataSvm {
     pub router:             Pubkey,
     #[serde_as(as = "DisplayFromStr")]
     pub permission_account: Pubkey,
-    #[serde_as(as = "DisplayFromStr")]
-    pub block_hash:         Hash,
-    pub slot:               Slot,
 }
 
 pub trait OpportunityMetadata:

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -72,31 +72,16 @@ impl Service<ChainTypeSvm> {
             }],
         };
 
-        // TODO use some in memory caching for this part
-        let (block_hash, _) = chain_store
-            .client
-            .get_latest_blockhash_with_commitment(CommitmentConfig {
-                commitment: CommitmentLevel::Finalized,
-            })
-            .map_err(|e| {
-                tracing::error!("Failed to get latest block hash: {:?}", e);
-                RestError::TemporarilyUnavailable
-            })
-            .await?;
-
         Ok(entities::OpportunityCreateSvm {
             core_fields,
             router,
             permission_account,
-            block_hash,
             program: entities::OpportunitySvmProgram::Phantom(
                 entities::OpportunitySvmProgramWallet {
                     user_wallet_address:         quote_create.user_wallet_address,
                     maximum_slippage_percentage: quote_create.maximum_slippage_percentage,
                 },
             ),
-            // TODO extract latest slot
-            slot: Slot::default(),
         })
     }
 


### PR DESCRIPTION
I think we can merge this. Tilt still passes.
svm-linonade aka `scripts/limonade/src/index.ts` submits the opportunity with the blockhash and slot, but to fix that I need to fix `@pythnetwork/express-relay-js` in pyth-crosschain.
I will also update simpleSearcherLimo there.