### PR TITLE
Fix/auction server lookup table

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -204,7 +204,7 @@ local_resource(
 # craft dummy tx, submits as a bid to auction server or submits relayer-signed tx directly to solana cluster
 local_resource(
     "svm-submit-bid",
-    "poetry -C per_sdk run python3 -m per_sdk.svm.dummy_tx -v --file-private-key-searcher keypairs/searcher.json --file-private-key-relayer-signer keypairs/relayer_signer.json --bid 100000000 --auction-server-url http://localhost:9000 --express-relay-program PytERJFhAKuNNuaiXkApLfWzwNwSNDACpigT3LwQfou --dummy-program DUmmYXYFZugRn2DS4REc5F9UbQNoxYsHP1VMZ6j5U7kZ",
+    "poetry -C per_sdk run python3 -m per_sdk.svm.dummy_tx -v --file-private-key-searcher keypairs/searcher.json --file-private-key-relayer-signer keypairs/relayer_signer.json --bid 100000000 --auction-server-url http://localhost:9000 --express-relay-program PytERJFhAKuNNuaiXkApLfWzwNwSNDACpigT3LwQfou --dummy-program DUmmYXYFZugRn2DS4REc5F9UbQNoxYsHP1VMZ6j5U7kZ --rpc-url %s --use-lookup-table" % rpc_url_solana,
     resource_deps=["svm-initialize-programs", "auction-server"],
 )
 

--- a/auction-server/src/auction.rs
+++ b/auction-server/src/auction.rs
@@ -943,11 +943,11 @@ async fn extract_account_svm(
     if account_position < accounts.len() {
         let account = accounts.get(account_position).ok_or_else(|| {
             tracing::error!(
-                "Account not found in transaction accounts: {:?} - {}",
+                "Account not found in static accounts: {:?} - {}",
                 accounts,
                 account_position,
             );
-            RestError::BadParameters("Account not found in transaction accounts".to_string())
+            RestError::BadParameters("Account not found in static accounts".to_string())
         })?;
 
         return Ok(*account);
@@ -989,9 +989,9 @@ async fn extract_account_svm(
             query_lookup_table(readable_accounts, account_position_lookups_readable, client).await
         }
         None => {
-            tracing::error!("Lookup tables not found where account_position {} exceeds number of static accounts {}", account_position, accounts.len());
+            tracing::error!("No lookup tables found where account_position {} exceeds number of static accounts {}", account_position, accounts.len());
             Err(RestError::BadParameters(
-                "Lookup tables not found in submit_bid instruction".to_string(),
+                "No lookup tables found in submit_bid instruction".to_string(),
             ))
         }
     }
@@ -1009,16 +1009,16 @@ async fn query_lookup_table(
                 lookup_accounts,
                 account_position,
             );
-            RestError::BadParameters("".to_string())
+            RestError::BadParameters("Lookup table not found in lookup accounts".to_string())
         })?;
 
     let table_data = client.get_account_data(table_to_query).await.map_err(|e| {
-        tracing::error!("Error while getting lookup table data: {:?}", e);
-        RestError::BadParameters("Error while getting lookup table data".to_string())
+        tracing::error!("Failed getting lookup table account data: {:?}", e);
+        RestError::BadParameters("Failed getting lookup table account data".to_string())
     })?;
     let table = AddressLookupTable::deserialize(&table_data).map_err(|e| {
-        tracing::error!("Error while deserializing lookup table data: {:?}", e);
-        RestError::BadParameters("Error while deserializing lookup table data".to_string())
+        tracing::error!("Failed deserializing lookup table account data: {:?}", e);
+        RestError::BadParameters("Failed deserializing lookup table account data".to_string())
     })?;
     let account = table
         .addresses

--- a/auction-server/src/auction.rs
+++ b/auction-server/src/auction.rs
@@ -940,8 +940,6 @@ async fn extract_account_svm(
     })?;
 
     let account_position: usize = (*account_position).into();
-    println!("account_position: {:?}", account_position);
-    println!("len of accounts: {:?}", accounts.len());
     if account_position < accounts.len() {
         let account = accounts.get(account_position).ok_or_else(|| {
             tracing::error!(

--- a/auction-server/src/auction.rs
+++ b/auction-server/src/auction.rs
@@ -987,9 +987,7 @@ async fn query_lookup_table(
     let table_data = client
         .get_account_with_commitment(table, CommitmentConfig::processed())
         .await
-        .map_err(|_e| {
-            RestError::BadParameters("Failed getting lookup table account data".to_string())
-        })?
+        .map_err(|_e| RestError::TemporarilyUnavailable)?
         .value
         .ok_or_else(|| RestError::BadParameters("Account not found".to_string()))?;
     let table_data_deserialized =

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -158,12 +158,14 @@ impl Service<ChainTypeSvm> {
         let winner_bid = bids.first().expect("failed to get first bid");
 
         // Find the submit bid instruction from bid transaction to extract the deadline
-        let submit_bid_instruction =
-            verify_submit_bid_instruction_svm(chain_store, winner_bid.transaction.clone())
-                .map_err(|e| {
-                    tracing::error!("Failed to verify submit bid instruction: {:?}", e);
-                    RestError::TemporarilyUnavailable
-                })?;
+        let submit_bid_instruction = verify_submit_bid_instruction_svm(
+            &chain_store.config.express_relay_program_id,
+            winner_bid.transaction.clone(),
+        )
+        .map_err(|e| {
+            tracing::error!("Failed to verify submit bid instruction: {:?}", e);
+            RestError::TemporarilyUnavailable
+        })?;
         let submit_bid_data = extract_submit_bid_data(&submit_bid_instruction).map_err(|e| {
             tracing::error!("Failed to extract submit bid data: {:?}", e);
             RestError::TemporarilyUnavailable

--- a/per_sdk/svm/dummy_tx.py
+++ b/per_sdk/svm/dummy_tx.py
@@ -181,10 +181,6 @@ async def main():
             ],
         )
 
-        print("recent slot", recent_slot)
-        for data in ix_create_lut.data:
-            print(data)
-
         tx_create_lut = Transaction(fee_payer=pk_searcher)
         tx_create_lut.add(ix_create_lut)
         tx_create_lut_sig = (
@@ -196,9 +192,11 @@ async def main():
             conf_create_lut.value[0].status is None
         ), "Create lookup table transaction failed"
 
+        print(recent_slot, pk_searcher, lookup_table_address)
         ix_extend_lut = Instruction(
             address_lookup_pid,
-            struct.pack("B", 2).join(
+            struct.pack("<L", 2)
+            + b"".join(
                 [
                     bytes(pubkey)
                     for pubkey in [router, config_router, pk_express_relay_metadata]


### PR DESCRIPTION
Initial changes to accommodate express relay `permission`/`router` accounts being passed via lookup tables as opposed to static account keys

Prior to this PR, the server assumes that the `permission` and `router` accounts are located in the static account keys of the submitted transaction. However, this may not be the case if the transaction is a `VersionedTransaction` that uses lookup tables. To remedy this, this PR performs an RPC call to get the accounts in the relevant lookup table if the queried account is not in the static account keys array.

In the future, we can improve upon this via caching of previously queried lookup tables. This should not worsen performance since in the case where the queried account is in the static account keys array, no RPC call is made.