### PR TITLE
add caching of lookup tables

### DIFF
--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -438,6 +438,7 @@ fn setup_svm(
                     wallet_program_router_account: chain_config.wallet_program_router_account,
                     config: chain_config,
                     express_relay_svm,
+                    lookup_table_cache: Default::default(),
                 },
             )
         })

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -480,6 +480,7 @@ pub struct ChainStoreSvm {
     pub express_relay_svm:             ExpressRelaySvm,
     pub wallet_program_router_account: Pubkey,
     pub name:                          String,
+    pub lookup_table_cache:            LookupTableCache,
 }
 
 pub type BidId = Uuid;
@@ -870,6 +871,8 @@ pub struct ExpressRelaySvm {
     pub permission_account_position: usize,
     pub router_account_position:     usize,
 }
+
+pub type LookupTableCache = RwLock<HashMap<Pubkey, Vec<Pubkey>>>;
 
 pub struct Store {
     pub chains:           HashMap<ChainId, Arc<ChainStoreEvm>>,


### PR DESCRIPTION
This PR adds a cache of lookup table data to the auction server, so that the server doesn't repeatedly make RPC calls to query the accounts held in lookup tables.

If the lookup table has new addresses added and a later index in the lookup table is queried, the server will requery the lookup table data via RPC.