### PR TITLE
fix: clippy warns fail pre-commit now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: cargo-clippy-auction-server
         name: Cargo clippy for auction server
         language: "rust"
-        entry: cargo +stable clippy --manifest-path ./auction-server/Cargo.toml --tests --fix --allow-dirty --allow-staged --  -D warnings
+        entry: cargo +stable clippy --manifest-path ./auction-server/Cargo.toml --tests -- -D warnings
         pass_filenames: false
         files: auction-server
       # Hooks for vault-simulator
@@ -40,7 +40,7 @@ repos:
       - id: cargo-clippy-vault-simulator
         name: Cargo clippy for vault simulator
         language: "rust"
-        entry: cargo +stable clippy --manifest-path ./vault-simulator/Cargo.toml --tests --fix --allow-dirty --allow-staged --  -D warnings
+        entry: cargo +stable clippy --manifest-path ./vault-simulator/Cargo.toml --tests -- -D warnings
         pass_filenames: false
         files: vault-simulator
       # Hooks for gas-oracle
@@ -53,7 +53,7 @@ repos:
       - id: cargo-clippy-gas-oracle
         name: Cargo clippy for gas oracle
         language: "rust"
-        entry: cargo +stable clippy --manifest-path ./gas-oracle/Cargo.toml --tests --fix --allow-dirty --allow-staged --  -D warnings
+        entry: cargo +stable clippy --manifest-path ./gas-oracle/Cargo.toml --tests -- -D warnings
         pass_filenames: false
         files: gas-oracle
       # Hooks for contracts-svm
@@ -66,7 +66,7 @@ repos:
       - id: cargo-clippy-contracts-svm
         name: Cargo clippy for svm contracts
         language: "rust"
-        entry: cargo +stable clippy --manifest-path ./contracts/svm/Cargo.toml --tests --fix --allow-dirty --allow-staged --  -D warnings
+        entry: cargo +stable clippy --manifest-path ./contracts/svm/Cargo.toml --tests -- -D warnings
         pass_filenames: false
         files: contracts/svm
       # For python files

--- a/auction-server/src/models.rs
+++ b/auction-server/src/models.rs
@@ -66,13 +66,16 @@ pub struct Profile {
     pub email: EmailAddress,
     pub role:  ProfileRole,
 
+    #[allow(dead_code)]
     pub created_at: PrimitiveDateTime,
+    #[allow(dead_code)]
     pub updated_at: PrimitiveDateTime,
 }
 
 pub type TokenId = Uuid;
 pub type AccessTokenToken = String;
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct AccessToken {
     pub id: TokenId,
 
@@ -137,6 +140,7 @@ pub enum BidMetadata {
 #[derive(Clone, Debug, FromRow)]
 pub struct Bid {
     pub id:              BidId,
+    #[allow(dead_code)]
     pub creation_time:   PrimitiveDateTime,
     pub permission_key:  Vec<u8>,
     pub chain_id:        String,

--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -141,6 +141,7 @@ pub enum OpportunityCreate {
 
 #[derive(Serialize, Deserialize, ToResponse, ToSchema, Clone)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum Opportunity {
     Evm(OpportunityEvm),
     Svm(OpportunitySvm),

--- a/auction-server/src/opportunity/entities/opportunity.rs
+++ b/auction-server/src/opportunity/entities/opportunity.rs
@@ -90,6 +90,7 @@ pub trait OpportunityCreate:
 pub enum OpportunityRemovalReason {
     Expired,
     // TODO use internal errors instead of RestError
+    #[allow(dead_code)]
     Invalid(RestError),
 }
 

--- a/auction-server/src/opportunity/repository/models.rs
+++ b/auction-server/src/opportunity/repository/models.rs
@@ -101,6 +101,7 @@ impl OpportunityMetadata for OpportunityMetadataSvm {
 
 // TODO Update metdata to exection_params
 #[derive(Clone, FromRow, Debug)]
+#[allow(dead_code)]
 pub struct Opportunity<T: OpportunityMetadata> {
     pub id:             Uuid,
     pub creation_time:  PrimitiveDateTime,

--- a/auction-server/src/opportunity/service/estimate_price.rs
+++ b/auction-server/src/opportunity/service/estimate_price.rs
@@ -10,6 +10,7 @@ use {
 };
 
 pub struct EstimatePriceInput {
+    #[allow(dead_code)]
     pub quote_create: entities::QuoteCreate,
 }
 

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -63,6 +63,7 @@ pub struct ConfigSvm {
     pub wallet_program_router_account: Pubkey,
 }
 
+#[allow(dead_code)]
 pub trait Config: Send + Sync {}
 
 impl Config for ConfigEvm {

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -180,6 +180,7 @@ pub struct SimulatedBidEvm {
 // TODO - we should delete this enum and use the SimulatedBidTrait instead. We may need it for API.
 #[derive(Clone, Debug, ToSchema, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum SimulatedBid {
     Evm(SimulatedBidEvm),
     Svm(SimulatedBidSvm),

--- a/contracts/svm/testing/src/express_relay/submit_bid.rs
+++ b/contracts/svm/testing/src/express_relay/submit_bid.rs
@@ -21,6 +21,7 @@ use {
     },
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn bid_instructions(
     relayer_signer: &Keypair,
     searcher: &Keypair,

--- a/contracts/svm/testing/src/helpers.rs
+++ b/contracts/svm/testing/src/helpers.rs
@@ -22,6 +22,7 @@ use {
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 pub const TX_FEE: u64 = 10_000; // TODO: make this programmatic? FeeStructure is currently private field within LiteSVM
 
+#[allow(clippy::result_large_err)]
 pub fn submit_transaction(
     svm: &mut litesvm::LiteSVM,
     ixs: &[Instruction],

--- a/vault-simulator/src/simulator.rs
+++ b/vault-simulator/src/simulator.rs
@@ -203,15 +203,14 @@ pub async fn run_simulator(simulator_options: SimulatorOptions) -> Result<()> {
     let min_permissionless_health_ratio =
         U256::exp10(18) * min_health_permissionless_numerator / min_health_denominator;
 
-    let collat_ratio: U256;
     let allow_undercollateralized: bool = contract.get_allow_undercollateralized().call().await?;
-    if allow_undercollateralized {
+    let collat_ratio: U256 = if allow_undercollateralized {
         // Less than min_health_ratio, greater than permissionless ratio, to create the vault undercollateralized
-        collat_ratio = (min_health_numerator + min_health_permissionless_numerator) / 2;
+        (min_health_numerator + min_health_permissionless_numerator) / 2
     } else {
         // Slightly more than min_health_ratio to create the vault overcollateralized
-        collat_ratio = min_health_numerator * 10_001 / 10_000;
-    }
+        min_health_numerator * 10_001 / 10_000
+    };
 
     let amount_collateral: U256 = collateral_value_usd * precision * collat_ratio
         / min_health_denominator


### PR DESCRIPTION
there is an on-going issue where if you run clippy with the `--fix` flag, the return code is always 0 even when it should fail.
I just removed the fix param for now to make sure we catch such issues firsthand.