### PR TITLE
Feat/get all live opps

### DIFF
--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -168,8 +168,8 @@ pub struct GetOpportunitiesQueryParams {
     #[param(example="2024-05-23T21:26:57.329954Z", value_type = Option<String>)]
     #[serde(default, with = "crate::serde::nullable_datetime")]
     pub from_time:      Option<OffsetDateTime>,
-    /// The maximum number of opportunities to return. Capped at 100.
-    #[param(example = "20", value_type = usize)]
+    /// The maximum number of opportunities to return. Capped at 100; if more than 100 requested, at most 100 will be returned.
+    #[param(example = "20", value_type = usize, maximum = 100)]
     #[serde(default = "default_limit")]
     limit:              usize,
 }

--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -736,10 +736,7 @@ pub async fn get_opportunities(
         Ok(Json(
             opportunities
                 .into_iter()
-                .take(std::cmp::min(
-                    query_params.limit,
-                    OPPORTUNITY_PAGE_SIZE_CAP as usize,
-                ))
+                .take(std::cmp::min(query_params.limit, OPPORTUNITY_PAGE_SIZE_CAP))
                 .collect(),
         ))
     }

--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -686,7 +686,7 @@ pub async fn post_opportunity(
 /// Fetch opportunities ready for execution or historical opportunities
 /// depending on the mode. You need to provide `chain_id` for historical mode.
 /// Opportunities are sorted by creation time in ascending order.
-/// Total number of opportunities returned is limited by 20.
+/// Total number of opportunities returned is capped by the server to preserve bandwidth.
 #[utoipa::path(get, path = "/v1/opportunities", responses(
 (status = 200, description = "Array of opportunities ready for bidding", body = Vec < Opportunity >),
 (status = 400, response = ErrorBodyResponse),

--- a/auction-server/src/opportunity/api.rs
+++ b/auction-server/src/opportunity/api.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        repository,
+        repository::OPPORTUNITY_PAGE_SIZE_CAP,
         service::{
             add_opportunity::AddOpportunityInput,
             get_opportunities::GetOpportunitiesInput,
@@ -150,6 +150,9 @@ pub enum Opportunity {
 fn default_opportunity_mode() -> OpportunityMode {
     OpportunityMode::Live
 }
+fn default_limit() -> usize {
+    20
+}
 #[derive(Clone, Serialize, Deserialize, IntoParams)]
 pub struct GetOpportunitiesQueryParams {
     #[param(example = "op_sepolia", value_type = Option < String >)]
@@ -161,10 +164,14 @@ pub struct GetOpportunitiesQueryParams {
     /// The permission key to filter the opportunities by. Used only in historical mode.
     #[param(example = "0xdeadbeef", value_type = Option< String >)]
     pub permission_key: Option<Bytes>,
-    /// The time to get the opportunities from. Used only in historical mode.
+    /// The time to get the opportunities from.
     #[param(example="2024-05-23T21:26:57.329954Z", value_type = Option<String>)]
     #[serde(default, with = "crate::serde::nullable_datetime")]
     pub from_time:      Option<OffsetDateTime>,
+    /// The maximum number of opportunities to return. Capped at 100.
+    #[param(example = "20", value_type = usize)]
+    #[serde(default = "default_limit")]
+    limit:              usize,
 }
 
 // ----- Evm types -----
@@ -678,7 +685,7 @@ pub async fn post_opportunity(
 
 /// Fetch opportunities ready for execution or historical opportunities
 /// depending on the mode. You need to provide `chain_id` for historical mode.
-/// Opportunities are sorted by creation time in ascending order in historical mode.
+/// Opportunities are sorted by creation time in ascending order.
 /// Total number of opportunities returned is limited by 20.
 #[utoipa::path(get, path = "/v1/opportunities", responses(
 (status = 200, description = "Array of opportunities ready for bidding", body = Vec < Opportunity >),
@@ -699,7 +706,7 @@ pub async fn get_opportunities(
     let opportunities_svm = store
         .opportunity_service_svm
         .get_opportunities(GetOpportunitiesInput {
-            query_params: query_params.0,
+            query_params: query_params.clone().0,
         })
         .await;
 
@@ -729,7 +736,10 @@ pub async fn get_opportunities(
         Ok(Json(
             opportunities
                 .into_iter()
-                .take(repository::OPPORTUNITY_PAGE_SIZE as usize)
+                .take(std::cmp::min(
+                    query_params.limit,
+                    OPPORTUNITY_PAGE_SIZE_CAP as usize,
+                ))
                 .collect(),
         ))
     }

--- a/auction-server/src/opportunity/entities/opportunity_evm.rs
+++ b/auction-server/src/opportunity/entities/opportunity_evm.rs
@@ -163,7 +163,7 @@ impl TryFrom<repository::Opportunity<repository::OpportunityMetadataEvm>> for Op
         Ok(OpportunityEvm {
             core_fields:       OpportunityCoreFields {
                 id: val.id,
-                creation_time: val.creation_time.assume_utc().unix_timestamp_nanos(),
+                creation_time: val.creation_time.assume_utc().unix_timestamp_nanos() / 1000,
                 permission_key: PermissionKey::from(val.permission_key),
                 chain_id: val.chain_id,
                 sell_tokens,

--- a/auction-server/src/opportunity/entities/opportunity_svm.rs
+++ b/auction-server/src/opportunity/entities/opportunity_svm.rs
@@ -217,7 +217,7 @@ impl TryFrom<repository::Opportunity<repository::OpportunityMetadataSvm>> for Op
         Ok(OpportunitySvm {
             core_fields: OpportunityCoreFields {
                 id: val.id,
-                creation_time: val.creation_time.assume_utc().unix_timestamp_nanos(),
+                creation_time: val.creation_time.assume_utc().unix_timestamp_nanos() / 1000,
                 permission_key: PermissionKey::from(val.permission_key),
                 chain_id: val.chain_id,
                 sell_tokens,

--- a/auction-server/src/opportunity/repository/get_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_opportunities.rs
@@ -44,7 +44,7 @@ impl<T: InMemoryStore> Repository<T> {
             query.push_bind(from_time);
         }
         query.push(" ORDER BY creation_time ASC LIMIT ");
-        query.push_bind(super::OPPORTUNITY_PAGE_SIZE);
+        query.push_bind(super::OPPORTUNITY_PAGE_SIZE_CAP);
         let opps: Vec<models::Opportunity<<T::Opportunity as entities::Opportunity>::ModelMetadata>> = query
             .build_query_as()
             .fetch_all(db)

--- a/auction-server/src/opportunity/repository/get_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_opportunities.rs
@@ -44,7 +44,7 @@ impl<T: InMemoryStore> Repository<T> {
             query.push_bind(from_time);
         }
         query.push(" ORDER BY creation_time ASC LIMIT ");
-        query.push_bind(super::OPPORTUNITY_PAGE_SIZE_CAP);
+        query.push_bind(super::OPPORTUNITY_PAGE_SIZE_CAP as i64);
         let opps: Vec<models::Opportunity<<T::Opportunity as entities::Opportunity>::ModelMetadata>> = query
             .build_query_as()
             .fetch_all(db)

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -21,7 +21,7 @@ mod remove_opportunities;
 mod remove_opportunity;
 
 pub use models::*;
-pub const OPPORTUNITY_PAGE_SIZE: i32 = 20;
+pub const OPPORTUNITY_PAGE_SIZE_CAP: i32 = 100;
 
 #[derive(Debug)]
 pub struct Repository<T: InMemoryStore> {

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -21,7 +21,7 @@ mod remove_opportunities;
 mod remove_opportunity;
 
 pub use models::*;
-pub const OPPORTUNITY_PAGE_SIZE_CAP: i32 = 100;
+pub const OPPORTUNITY_PAGE_SIZE_CAP: usize = 100;
 
 #[derive(Debug)]
 pub struct Repository<T: InMemoryStore> {

--- a/auction-server/src/opportunity/service/get_opportunities.rs
+++ b/auction-server/src/opportunity/service/get_opportunities.rs
@@ -42,11 +42,18 @@ impl<T: ChainType> Service<T> {
                     opportunity.clone()
                 })
                 .filter(|opportunity| {
-                    if let Some(chain_id) = &query_params.chain_id {
+                    let filter_time = if let Some(from_time) = query_params.from_time {
+                        opportunity.creation_time >= from_time.unix_timestamp_nanos() / 1000
+                    } else {
+                        true
+                    };
+
+                    let filter_chain_id = if let Some(chain_id) = &query_params.chain_id {
                         opportunity.chain_id == *chain_id
                     } else {
                         true
-                    }
+                    };
+                    filter_time && filter_chain_id
                 })
                 .collect()),
             OpportunityMode::Historical => {

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/express-relay-js",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/express-relay-js",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.2",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/express-relay-js",
-      "version": "0.13.2",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/per/tree/main/sdk/js",
   "author": "Douro Labs",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/per/tree/main/sdk/js",
   "author": "Douro Labs",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.13.2",
+  "version": "0.13.1",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/per/tree/main/sdk/js",
   "author": "Douro Labs",

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -265,12 +265,25 @@ export class Client {
   /**
    * Fetches opportunities
    * @param chainId Chain id to fetch opportunities for. e.g: sepolia
+   * @param fromTime Minimum Unix timestamp of the returned opportunities, in microseconds
+   * @param limit Number of opportunities to return
    * @returns List of opportunities
    */
-  async getOpportunities(chainId?: string): Promise<Opportunity[]> {
+  async getOpportunities(
+    chainId?: string,
+    fromTime?: number,
+    limit?: number
+  ): Promise<Opportunity[]> {
     const client = createClient<paths>(this.clientOptions);
+    const fromTimeStr = fromTime
+      ? `${new Date(fromTime / 1000).toISOString().replace("Z", "")}${(
+          fromTime % 1000
+        )
+          .toString()
+          .padStart(3, "0")}Z`
+      : undefined;
     const opportunities = await client.GET("/v1/opportunities", {
-      params: { query: { chain_id: chainId } },
+      params: { query: { chain_id: chainId, from_time: fromTimeStr, limit } },
     });
     if (opportunities.data === undefined) {
       throw new ClientError("No opportunities found");

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -265,25 +265,20 @@ export class Client {
   /**
    * Fetches opportunities
    * @param chainId Chain id to fetch opportunities for. e.g: sepolia
-   * @param fromTime Minimum Unix timestamp of the returned opportunities, in microseconds
+   * @param fromTime A date object representing the datetime to fetch opportunities from. If undefined, fetches from the beginning of time.
    * @param limit Number of opportunities to return
    * @returns List of opportunities
    */
   async getOpportunities(
     chainId?: string,
-    fromTime?: number,
+    fromTime?: Date,
     limit?: number
   ): Promise<Opportunity[]> {
     const client = createClient<paths>(this.clientOptions);
-    const fromTimeStr = fromTime
-      ? `${new Date(fromTime / 1000).toISOString().replace("Z", "")}${(
-          fromTime % 1000
-        )
-          .toString()
-          .padStart(3, "0")}Z`
-      : undefined;
     const opportunities = await client.GET("/v1/opportunities", {
-      params: { query: { chain_id: chainId, from_time: fromTimeStr, limit } },
+      params: {
+        query: { chain_id: chainId, from_time: fromTime?.toISOString(), limit },
+      },
     });
     if (opportunities.data === undefined) {
       throw new ClientError("No opportunities found");

--- a/sdk/js/src/serverTypes.d.ts
+++ b/sdk/js/src/serverTypes.d.ts
@@ -25,7 +25,7 @@ export interface paths {
     /**
      * Fetch opportunities ready for execution or historical opportunities
      * @description depending on the mode. You need to provide `chain_id` for historical mode.
-     * Opportunities are sorted by creation time in ascending order in historical mode.
+     * Opportunities are sorted by creation time in ascending order.
      * Total number of opportunities returned is limited by 20.
      */
     get: operations["get_opportunities"];
@@ -900,7 +900,7 @@ export interface operations {
   /**
    * Fetch opportunities ready for execution or historical opportunities
    * @description depending on the mode. You need to provide `chain_id` for historical mode.
-   * Opportunities are sorted by creation time in ascending order in historical mode.
+   * Opportunities are sorted by creation time in ascending order.
    * Total number of opportunities returned is limited by 20.
    */
   get_opportunities: {
@@ -916,10 +916,15 @@ export interface operations {
          */
         permission_key?: string | null;
         /**
-         * @description The time to get the opportunities from. Used only in historical mode.
+         * @description The time to get the opportunities from.
          * @example 2024-05-23T21:26:57.329954Z
          */
         from_time?: string | null;
+        /**
+         * @description The maximum number of opportunities to return. Capped at 100.
+         * @example 20
+         */
+        limit?: number;
       };
     };
     responses: {

--- a/sdk/python/express_relay/client.py
+++ b/sdk/python/express_relay/client.py
@@ -385,18 +385,24 @@ class ExpressRelayClient:
                 future = self.ws_msg_futures.pop(msg_json["id"])
                 future.set_result(msg_json)
 
-    async def get_opportunities(self, chain_id: str | None = None) -> list[Opportunity]:
+    async def get_opportunities(self, chain_id: str | None = None, from_time: datetime | None = None, limit: int | None = None) -> list[Opportunity]:
         """
         Connects to the server and fetches opportunities.
 
         Args:
             chain_id: The chain ID to fetch opportunities for. If None, fetches opportunities across all chains.
+            from_time: The datetime to fetch opportunities from. If None, fetches from the beginning of time.
+            limit: Number of opportunities to fetch. If None, uses the default server limit.
         Returns:
             A list of opportunities.
         """
         params = {}
         if chain_id:
             params["chain_id"] = chain_id
+        if from_time:
+            params["from_time"] = from_time.astimezone().isoformat(timespec="microseconds")
+        if limit:
+            params["limit"] = str(limit)
 
         async with httpx.AsyncClient(**self.http_options) as client:
             resp = await client.get(

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "express-relay"
-version = "0.13.0"
+version = "0.13.1"
 description = "Utilities for searchers and protocols to interact with the Express Relay protocol."
 authors = ["dourolabs"]
 license = "Apache-2.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "express-relay"
-version = "0.13.2"
+version = "0.13.0"
 description = "Utilities for searchers and protocols to interact with the Express Relay protocol."
 authors = ["dourolabs"]
 license = "Apache-2.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "express-relay"
-version = "0.13.1"
+version = "0.13.2"
 description = "Utilities for searchers and protocols to interact with the Express Relay protocol."
 authors = ["dourolabs"]
 license = "Apache-2.0"


### PR DESCRIPTION
This PR adds options to help users get all live opportunities from the server, by paginating by time and altering the number of returned opportunities in the response.