### PR TITLE
Remove removal loop from limonade

### DIFF
--- a/scripts/limonade/package-lock.json
+++ b/scripts/limonade/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "limonade",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "limonade",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "APACHE-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",
         "@coral-xyz/anchor-cli": "^0.30.1",
         "@kamino-finance/limo-sdk": "^0.6.0",
-        "@pythnetwork/express-relay-js": "^0.13.1",
+        "@pythnetwork/express-relay-js": "^0.13.2",
         "@solana/web3.js": "^1.95.3",
         "axios": "^1.7.3",
         "bs58": "^6.0.0",
@@ -616,9 +616,9 @@
       }
     },
     "node_modules/@pythnetwork/express-relay-js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/express-relay-js/-/express-relay-js-0.13.1.tgz",
-      "integrity": "sha512-Y1o1jxjKGGtssnNPRk9SuNU7wTM86ryrpvX4MLyYuUReXqvuSdEi52hfrWajRVEwANVFmMdYP0VG8H5neoAzOQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/express-relay-js/-/express-relay-js-0.13.2.tgz",
+      "integrity": "sha512-+eQboi2Qv/mDkEdN4HKMNgE4jwduyTlj/17ytrYshI9c4W7DVaHmqTw2vRBSudFAs/7If6tmBX5SbjK62OsZiQ==",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",
         "@kamino-finance/limo-sdk": "^0.6.0",

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limonade",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "This script is used to submit new opportunities fetched from the limo program to the express relay.",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "@coral-xyz/anchor": "^0.30.1",
     "@coral-xyz/anchor-cli": "^0.30.1",
     "@kamino-finance/limo-sdk": "^0.6.0",
-    "@pythnetwork/express-relay-js": "^0.13.1",
+    "@pythnetwork/express-relay-js": "^0.13.2",
     "@solana/web3.js": "^1.95.3",
     "axios": "^1.7.3",
     "bs58": "^6.0.0",

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -7,11 +7,14 @@ import { limoId, Order } from "@kamino-finance/limo-sdk";
 import bs58 from "bs58";
 import { hideBin } from "yargs/helpers";
 import yargs from "yargs";
-import { Client, OpportunityCreate } from "@pythnetwork/express-relay-js";
+import {
+  ChainType,
+  Client,
+  OpportunityCreate,
+} from "@pythnetwork/express-relay-js";
 import { getPdaAuthority } from "@kamino-finance/limo-sdk/dist/utils";
 
 const lastChange: Record<string, number> = {};
-const existingAccounts = new Set<string>();
 
 const argv = yargs(hideBin(process.argv))
   .option("endpoint", {
@@ -71,39 +74,12 @@ async function run() {
   let { blockhash: latestBlockhash } = await connection.getLatestBlockhash(
     "confirmed"
   );
-  const removeClosedAccounts = async () => {
-    const response = await connection.getProgramAccounts(limoId, {
-      commitment: "confirmed",
-      filters,
-      withContext: true,
-    });
-    existingAccounts.forEach(async (key) => {
-      if (response.value.find((account) => account.pubkey.toBase58() === key)) {
-        return;
-      }
 
-      try {
-        await client.removeOpportunity({
-          program: "limo",
-          chainId: argv.chainId,
-          permissionAccount: new PublicKey(key),
-          router: getPdaAuthority(limoId, globalConfig),
-        });
-        existingAccounts.delete(key);
-      } catch (e) {
-        console.error("Failed to remove opportunity", e);
-      }
-    });
-  };
   const submitExistingOpportunities = async () => {
     const response = await connection.getProgramAccounts(limoId, {
       commitment: "confirmed",
       filters,
       withContext: true,
-    });
-
-    response.value.forEach((account) => {
-      existingAccounts.add(account.pubkey.toBase58());
     });
 
     const payloads: OpportunityCreate[] = response.value
@@ -145,18 +121,17 @@ async function run() {
     limoId,
     async (info, context) => {
       const order = Order.decode(info.accountInfo.data);
-      existingAccounts.add(info.accountId.toBase58());
       if (order.remainingInputAmount.toNumber() === 0) {
         const router = getPdaAuthority(limoId, globalConfig);
 
         try {
           await client.removeOpportunity({
+            chainType: ChainType.SVM,
             program: "limo",
             chainId: argv.chainId,
             permissionAccount: info.accountId,
             router,
           });
-          existingAccounts.delete(info.accountId.toBase58());
         } catch (e) {
           console.error("Failed to remove opportunity", e);
         }
@@ -208,16 +183,8 @@ async function run() {
       await new Promise((resolve) => setTimeout(resolve, 60 * 1000));
     }
   };
-  const removeClosedAccountsLoop = async () => {
-    while (true) {
-      removeClosedAccounts().catch(console.error);
-      // Wait for 30 seconds before running it again
-      await new Promise((resolve) => setTimeout(resolve, 30 * 1000));
-    }
-  };
 
   resubmitOpportunities().catch(console.error);
-  removeClosedAccountsLoop().catch(console.error);
   updateLatestBlockhash().catch(console.error);
 }
 


### PR DESCRIPTION
This PR aims to ignore closed accounts in limonade scripts and remove the removal loop. The auction server will expire opps after a minute, so we don't need to send an update for closed accounts and server will take care of it.