### PR TITLE
Fix get bid status for svm expired

### DIFF
--- a/auction-server/Cargo.lock
+++ b/auction-server/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -945,6 +945,8 @@ impl BidStatusTrait for BidStatusSvm {
                     Ok(BidStatusSvm::Won { result })
                 } else if bid.status == models::BidStatus::Submitted {
                     Ok(BidStatusSvm::Submitted { result })
+                } else if bid.status == models::BidStatus::Expired {
+                    Ok(BidStatusSvm::Expired { result })
                 } else {
                     Err(anyhow::anyhow!("Invalid bid status".to_string()))
                 }


### PR DESCRIPTION
This PR aims to resolve the bug of get_bid_status api for svm bids with expired status