### PR TITLE
feat: retry logic for svm sending transactions

### DIFF
--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -672,7 +672,10 @@ impl ChainStoreSvm {
         let signature_bs58 = bs58::encode(res).into_string();
         task_tracker.spawn(async move {
             for _ in 0..SVM_SEND_TRANSACTION_RETRY_COUNT {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                // Do not wait for the logs to be received
+                // just check if the transaction is in the logs already
                 while let Ok(log) = receiver.try_recv() {
                     if log.value.signature.eq(&signature_bs58) {
                         return;

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -656,11 +656,9 @@ impl ChainStoreSvm {
         task_tracker: TaskTracker,
     ) -> solana_client::client_error::Result<Signature> {
         let config = RpcSendTransactionConfig {
-            skip_preflight:       true,
-            preflight_commitment: None,
-            encoding:             None,
-            max_retries:          None,
-            min_context_slot:     None,
+            skip_preflight: true,
+            max_retries: Some(0),
+            ..RpcSendTransactionConfig::default()
         };
         let res = self
             .tx_broadcaster_client


### PR DESCRIPTION
Use tokio broadcast to have multiple subscribers to rpc logs. One for concluding the auctions and the other for stopping resubmission of transactions.