### PR TITLE
fix: add api key + docs on flags

### DIFF
--- a/scripts/dex-router/README.md
+++ b/scripts/dex-router/README.md
@@ -33,3 +33,13 @@ npm run dex-router -- \
 ```
 
 This command will subscribe to Limo opportunities with the `development-solana` chain ID and create 0-SOL bids to submit to the auction server that route the order through on-chain liquidity using the `FlashTakeOrder` functionality of the Limo program.
+
+### Optional Flags
+
+You can also add the following optional flags:
+
+- `--lookup-table-addresses`: a space-separated list of public keys corresponding to lookup tables to create versioned transactions with.
+- `--options-max-accounts-jupiter`: a space-separated list of options for the max number of accounts to include in Jupiter instructions. Each option will spawn a unique Jupiter router that is limited in the number of distinct accounts it can incorporate in the swap instructions.
+- `--jupiter-api-endpoint`: the Jupiter API endpoint from which to receive quotes and swap instructions. If not provided, defaults to the public endpoint.
+- `--jupiter-api-key`: the API key to use for authentication with the Jupiter API endpoint.
+- `--express-relay-server-api-key`: the API key to use for authentication with the Express Relay server.

--- a/scripts/dex-router/package-lock.json
+++ b/scripts/dex-router/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-router",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-router",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/dex-router/package.json
+++ b/scripts/dex-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-router",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Client to route Express Relay SVM orders to on-chain liquidity sources",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/dex-router/src/index.ts
+++ b/scripts/dex-router/src/index.ts
@@ -59,11 +59,13 @@ export class DexRouter {
     maxAccountsJupiter: number[],
     jupiterApiEndpoint: string,
     jupiterApiKey?: string,
-    baseLookupTableAddresses?: PublicKey[]
+    baseLookupTableAddresses?: PublicKey[],
+    expressRelayServerApiKey?: string
   ) {
     this.client = new Client(
       {
         baseUrl: endpoint,
+        apiKey: expressRelayServerApiKey,
       },
       undefined,
       this.opportunityHandler.bind(this),
@@ -424,6 +426,12 @@ const argv = yargs(hideBin(process.argv))
     type: "string",
     demandOption: false,
   })
+  .option("express-relay-server-api-key", {
+    description:
+      "API key to authenticate with the express relay server for submitting bids.",
+    type: "string",
+    demandOption: true,
+  })
   .help()
   .alias("help", "h")
   .parseSync();
@@ -440,7 +448,8 @@ async function run() {
     ),
     argv["jupiter-api-endpoint"],
     argv["jupiter-api-key"],
-    argv["lookup-table-addresses"]?.map((address) => new PublicKey(address))
+    argv["lookup-table-addresses"]?.map((address) => new PublicKey(address)),
+    argv["express-relay-server-api-key"]
   );
   checkRpcHealth(connection, HEALTH_RPC_THRESHOLD, HEALTH_RPC_INTERVAL).catch(
     console.error


### PR DESCRIPTION
This PR adds an Express Relay server API key flag to the dex router to help identify the source of bids on the database side. It also adds some documentation to the README