### PR TITLE
limonade: bump express-relay sdk and remove direct http checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,11 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
+  rules: {
+    "@typescript-eslint/no-misused-promises": "error",
+  },
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
 };

--- a/scripts/limonade/package-lock.json
+++ b/scripts/limonade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "limonade",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "limonade",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "APACHE-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/limonade/package-lock.json
+++ b/scripts/limonade/package-lock.json
@@ -12,7 +12,7 @@
         "@coral-xyz/anchor": "^0.30.1",
         "@coral-xyz/anchor-cli": "^0.30.1",
         "@kamino-finance/limo-sdk": "^0.7.1",
-        "@pythnetwork/express-relay-js": "^0.15.0",
+        "@pythnetwork/express-relay-js": "^0.15.1",
         "@solana/web3.js": "^1.95.3",
         "axios": "^1.7.3",
         "bs58": "^6.0.0",
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@pythnetwork/express-relay-js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/express-relay-js/-/express-relay-js-0.15.0.tgz",
-      "integrity": "sha512-1MMzfkhNE9gOuVFccHxHLM9COlVKKcm0omeWKLQmvVc9+MQnICv1edT1czZhQ3IKAEOuycYZyLr19RmrGjYd3Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/express-relay-js/-/express-relay-js-0.15.1.tgz",
+      "integrity": "sha512-k6AXTWVOqrp01wOK5zAKFXglF4lVljdrva/MA/zIWL9PLDtflP3ahcPtaP4aMeKot2yPk9PGYGnYvzC3AcGARA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limonade",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "This script is used to submit new opportunities fetched from the limo program to the express relay.",
   "main": "index.js",
   "scripts": {

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -22,7 +22,7 @@
     "@coral-xyz/anchor": "^0.30.1",
     "@coral-xyz/anchor-cli": "^0.30.1",
     "@kamino-finance/limo-sdk": "^0.7.1",
-    "@pythnetwork/express-relay-js": "^0.15.0",
+    "@pythnetwork/express-relay-js": "^0.15.1",
     "@solana/web3.js": "^1.95.3",
     "axios": "^1.7.3",
     "bs58": "^6.0.0",

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -101,20 +101,22 @@ async function run() {
       );
 
     console.log("Resubmitting opportunities", payloads.length);
-    for (const payload of payloads) {
-      try {
-        await client.submitOpportunity(payload);
-      } catch (e) {
-        if (
-          e instanceof ClientError &&
-          e.message.includes("Same opportunity is submitted recently")
-        ) {
-          console.log(e); // We don't want to pollute stderr with this
-        } else {
-          console.error(e);
+    await Promise.all(
+      payloads.map(async (payload) => {
+        try {
+          await client.submitOpportunity(payload);
+        } catch (e) {
+          if (
+            e instanceof ClientError &&
+            e.message.includes("Same opportunity is submitted recently")
+          ) {
+            console.log(e); // We don't want to pollute stderr with this
+          } else {
+            console.error(e);
+          }
         }
-      }
-    }
+      })
+    );
   };
 
   connection.onProgramAccountChange(


### PR DESCRIPTION
- remove direct `/live` checks
- send all `submitOpportunity` calls concurrently
- filter out duplicate opportunity errors to not pollute stderr
- handle rejects in the callback inside `onProgramAccountChange`