### PR TITLE
Fix capitalization error in "Development with Tilt" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that for the Solana CLI, you may need to alter your terminal's `PATH` varia
 Run `tilt up` in the root of the repo to start the development environment.
 You can access the ui at `http://localhost:10350/`.
 
-Here is what Tilt up does in order:
+Here is what `tilt up` does in order:
 
 1. [EVM] Starts `anvil`: local EVM chain to test the contracts with
 2. [EVM] Deploy express relay contracts

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that for the Solana CLI, you may need to alter your terminal's `PATH` varia
 Run `tilt up` in the root of the repo to start the development environment.
 You can access the ui at `http://localhost:10350/`.
 
-Here is what tilt up does in order:
+Here is what Tilt up does in order:
 
 1. [EVM] Starts `anvil`: local EVM chain to test the contracts with
 2. [EVM] Deploy express relay contracts


### PR DESCRIPTION
**Description:**  
Corrected a capitalization error in the "Development with Tilt" section of the documentation.  

- The phrase *"Here is what tilt up does in order:"* has been updated to *"Here is what Tilt up does in order:"*.  
- The word "Tilt" is now properly capitalized to align with the tool's official name.  

This fix enhances the professionalism and clarity of the documentation, ensuring that readers can easily recognize "Tilt" as a proper noun and the name of a specific development tool. Accurate and polished documentation is crucial for maintaining user trust and reducing potential confusion.