### PR TITLE
chore: add websocket timeout to limonade

### DIFF
--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -55,7 +55,7 @@ const argv = yargs(hideBin(process.argv))
   .option("solana-websocket-timeout", {
     description: "Solana websocket timeout (milliseconds)",
     type: "number",
-    default: 10 * 1000,
+    default: 30 * 1000,
   })
   .help()
   .alias("help", "h")

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -187,8 +187,7 @@ async function run() {
       filters,
     }
   );
-  connection.onSlotChange((slot) => {
-    console.log("Slot changed", slot.slot);
+  connection.onSlotChange(() => {
     if (solanaConnectionTimeout !== undefined) {
       clearTimeout(solanaConnectionTimeout);
     }

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -187,7 +187,8 @@ async function run() {
       filters,
     }
   );
-  connection.onSlotChange(() => {
+  connection.onSlotChange((slot) => {
+    console.log("Slot changed", slot.slot);
     if (solanaConnectionTimeout !== undefined) {
       clearTimeout(solanaConnectionTimeout);
     }


### PR DESCRIPTION
We might want to make limonade crash if the websocket is not working (since that's the lowest latency path for opportunities to be published).
This PR adds a timeout for the websocket leveraging the onSlotChange subscription. If there are not new slots for 30 seconds, we will assume the websocket doesn't work and crash.

