### PR TITLE
fix: check rent exemptions manually after the simulation

### DIFF
--- a/auction-server/src/auction/service/handle_bid.rs
+++ b/auction-server/src/auction/service/handle_bid.rs
@@ -21,7 +21,10 @@ impl<T: ChainTrait> Service<T>
 where
     Service<T>: Verification<T>,
 {
-    #[tracing::instrument(skip_all, fields(bid_id, profile_name, simulation_error))]
+    #[tracing::instrument(
+        skip_all,
+        fields(bid_id, profile_name, simulation_error, permission_key)
+    )]
     pub async fn handle_bid(
         &self,
         input: HandleBidInput<T>,

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -186,6 +186,8 @@ impl Verification<Evm> for Service<Evm> {
         input: VerifyBidInput<Evm>,
     ) -> Result<VerificationResult<Evm>, RestError> {
         let bid = input.bid_create;
+        tracing::Span::current()
+            .record("permission_key", bid.chain_data.permission_key.to_string());
         let call = self.get_simulation_call(
             bid.chain_data.permission_key.clone(),
             vec![MulticallData::from((
@@ -671,6 +673,7 @@ impl Verification<Svm> for Service<Svm> {
             transaction:        bid.chain_data.transaction.clone(),
         };
         let permission_key = bid_chain_data.get_permission_key();
+        tracing::Span::current().record("permission_key", bid_data.permission_account.to_string());
         self.check_deadline(&permission_key, bid_data.deadline)
             .await?;
         self.verify_signatures(&bid, &bid_chain_data).await?;

--- a/sdk/python/express_relay/svm/limo_client.py
+++ b/sdk/python/express_relay/svm/limo_client.py
@@ -127,7 +127,7 @@ class LimoClient:
         Returns necessary instructions to create, fill and close a wrapped SOL account.
         Creation instruction is idempotent.
         Filling instruction doesn't take into account the current WSOL balance.
-        Closing instruction unwraps all the WSOL back to the owner, even if it was deposited by another transaction.
+        Closing instruction always closes the WSOL account and unwraps all WSOL back to SOL.
         Args:
             owner: Who owns the WSOL token account
             payer: Who pays for the instructions


### PR DESCRIPTION
This is in progress on litesvm package:
https://github.com/LiteSVM/litesvm/issues/98

For testing, I added a dummy instruction into searchers transaction that transfers 3 lamports to an empty account. It was not failing before the change but it was after the change.