### PR TITLE
feat: make limonade smart

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         version: 5.5.4
       viem:
         specifier: "catalog:"
-        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
     devDependencies:
       "@types/yargs":
         specifier: "catalog:"
@@ -144,6 +144,9 @@ importers:
       "@pythnetwork/express-relay-js":
         specifier: workspace:*
         version: link:../../sdk/js
+      "@pythnetwork/hermes-client":
+        specifier: ^1.2.0
+        version: 1.2.0(axios@1.7.8)
       "@solana/web3.js":
         specifier: "catalog:"
         version: 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -153,6 +156,12 @@ importers:
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
+      joi:
+        specifier: ^17.13.3
+        version: 17.13.3
+      yaml:
+        specifier: ^2.6.1
+        version: 2.6.1
       yargs:
         specifier: "catalog:"
         version: 17.7.2
@@ -177,7 +186,7 @@ importers:
         version: 10.4.3
       viem:
         specifier: "catalog:"
-        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
       yargs:
         specifier: "catalog:"
         version: 17.7.2
@@ -227,13 +236,13 @@ importers:
     dependencies:
       "@pythnetwork/express-relay-evm-js":
         specifier: ^0.8.1
-        version: 0.8.1(axios@1.7.8)(bufferutil@4.0.8)(js-yaml@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 0.8.1(axios@1.7.8)(bufferutil@4.0.8)(js-yaml@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
       axios:
         specifier: ^1.7.3
         version: 1.7.8
       viem:
         specifier: "catalog:"
-        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
       yargs:
         specifier: "catalog:"
         version: 17.7.2
@@ -276,7 +285,7 @@ importers:
         version: 0.8.2
       viem:
         specifier: "catalog:"
-        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
       ws:
         specifier: ^8.17.1
         version: 8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -680,6 +689,18 @@ packages:
       }
     engines: { node: ">=14" }
 
+  "@hapi/hoek@9.3.0":
+    resolution:
+      {
+        integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
+      }
+
+  "@hapi/topo@5.1.0":
+    resolution:
+      {
+        integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
+      }
+
   "@humanwhocodes/config-array@0.13.0":
     resolution:
       {
@@ -926,6 +947,12 @@ packages:
       }
     deprecated: Please use '@pythnetwork/express-relay-js' instead.
 
+  "@pythnetwork/hermes-client@1.2.0":
+    resolution:
+      {
+        integrity: sha512-FO/5734g39zZf9dFUdLOVo38N8cFmhU/ls7W5dnAQax7ivPU6/FtSMEljJN26EE0nDK5JzOzcEM7FeckywiSyQ==,
+      }
+
   "@pythnetwork/price-service-client@1.9.0":
     resolution:
       {
@@ -967,6 +994,24 @@ packages:
     resolution:
       {
         integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==,
+      }
+
+  "@sideway/address@4.1.5":
+    resolution:
+      {
+        integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
+      }
+
+  "@sideway/formula@3.0.1":
+    resolution:
+      {
+        integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
+      }
+
+  "@sideway/pinpoint@2.0.0":
+    resolution:
+      {
+        integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
       }
 
   "@sinonjs/commons@1.8.6":
@@ -1331,6 +1376,15 @@ packages:
       {
         integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==,
       }
+
+  "@zodios/core@10.9.6":
+    resolution:
+      {
+        integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==,
+      }
+    peerDependencies:
+      axios: ^0.x || ^1.0.0
+      zod: ^3.x
 
   JSONStream@1.3.5:
     resolution:
@@ -2268,6 +2322,13 @@ packages:
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
 
+  eventsource@2.0.2:
+    resolution:
+      {
+        integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==,
+      }
+    engines: { node: ">=12.0.0" }
+
   execa@5.1.1:
     resolution:
       {
@@ -3075,6 +3136,12 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
+
+  joi@17.13.3:
+    resolution:
+      {
+        integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==,
+      }
 
   js-sha256@0.9.0:
     resolution:
@@ -4502,6 +4569,14 @@ packages:
         integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
       }
 
+  yaml@2.6.1:
+    resolution:
+      {
+        integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==,
+      }
+    engines: { node: ">= 14" }
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution:
       {
@@ -4557,6 +4632,12 @@ packages:
         integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
       }
     engines: { node: ">=10" }
+
+  zod@3.24.1:
+    resolution:
+      {
+        integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==,
+      }
 
 snapshots:
   "@adraffy/ens-normalize@1.10.0": {}
@@ -4840,6 +4921,12 @@ snapshots:
   "@eslint/js@8.57.1": {}
 
   "@fastify/busboy@2.1.1": {}
+
+  "@hapi/hoek@9.3.0": {}
+
+  "@hapi/topo@5.1.0":
+    dependencies:
+      "@hapi/hoek": 9.3.0
 
   "@humanwhocodes/config-array@0.13.0":
     dependencies:
@@ -5126,12 +5213,12 @@ snapshots:
 
   "@openzeppelin/contracts@4.9.6": {}
 
-  "@pythnetwork/express-relay-evm-js@0.8.1(axios@1.7.8)(bufferutil@4.0.8)(js-yaml@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)":
+  "@pythnetwork/express-relay-evm-js@0.8.1(axios@1.7.8)(bufferutil@4.0.8)(js-yaml@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)":
     dependencies:
       isomorphic-ws: 5.0.0(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       openapi-client-axios: 7.5.5(axios@1.7.8)(js-yaml@4.1.0)
       openapi-fetch: 0.8.2
-      viem: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)
+      viem: 2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1)
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - axios
@@ -5140,6 +5227,14 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  "@pythnetwork/hermes-client@1.2.0(axios@1.7.8)":
+    dependencies:
+      "@zodios/core": 10.9.6(axios@1.7.8)(zod@3.24.1)
+      eventsource: 2.0.2
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - axios
 
   "@pythnetwork/price-service-client@1.9.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)":
     dependencies:
@@ -5182,6 +5277,14 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.3.2
       "@scure/base": 1.1.9
+
+  "@sideway/address@4.1.5":
+    dependencies:
+      "@hapi/hoek": 9.3.0
+
+  "@sideway/formula@3.0.1": {}
+
+  "@sideway/pinpoint@2.0.0": {}
 
   "@sinonjs/commons@1.8.6":
     dependencies:
@@ -5477,6 +5580,11 @@ snapshots:
 
   "@ungap/structured-clone@1.2.0": {}
 
+  "@zodios/core@10.9.6(axios@1.7.8)(zod@3.24.1)":
+    dependencies:
+      axios: 1.7.8
+      zod: 3.24.1
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -5484,9 +5592,10 @@ snapshots:
 
   abab@2.0.6: {}
 
-  abitype@1.0.4(typescript@5.5.4):
+  abitype@1.0.4(typescript@5.5.4)(zod@3.24.1):
     optionalDependencies:
       typescript: 5.5.4
+      zod: 3.24.1
 
   acorn-globals@6.0.0:
     dependencies:
@@ -6000,6 +6109,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.1: {}
+
+  eventsource@2.0.2: {}
 
   execa@5.1.1:
     dependencies:
@@ -6765,6 +6876,14 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  joi@17.13.3:
+    dependencies:
+      "@hapi/hoek": 9.3.0
+      "@hapi/topo": 5.1.0
+      "@sideway/address": 4.1.5
+      "@sideway/formula": 3.0.1
+      "@sideway/pinpoint": 2.0.0
+
   js-sha256@0.9.0: {}
 
   js-tokens@4.0.0: {}
@@ -7435,14 +7554,14 @@ snapshots:
       convert-source-map: 1.9.0
       source-map: 0.7.4
 
-  viem@2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10):
+  viem@2.16.2(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.24.1):
     dependencies:
       "@adraffy/ens-normalize": 1.10.0
       "@noble/curves": 1.2.0
       "@noble/hashes": 1.3.2
       "@scure/bip32": 1.3.2
       "@scure/bip39": 1.2.1
-      abitype: 1.0.4(typescript@5.5.4)
+      abitype: 1.0.4(typescript@5.5.4)(zod@3.24.1)
       isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -7545,6 +7664,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yaml@2.6.1: {}
+
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -7591,3 +7712,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     typescript:
       specifier: 5.5.4
       version: 5.5.4
+    viem:
+      specifier: 2.16.2
+      version: 2.16.2
     yargs:
       specifier: 17.7.2
       version: 17.7.2
@@ -144,6 +147,9 @@ importers:
       "@pythnetwork/hermes-client":
         specifier: ^1.2.0
         version: 1.2.0(axios@1.7.8)
+      "@solana/spl-token":
+        specifier: ^0.4.9
+        version: 0.4.9(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)
       "@solana/web3.js":
         specifier: "catalog:"
         version: 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -1062,6 +1068,15 @@ packages:
     peerDependencies:
       typescript: ">=5"
 
+  "@solana/spl-token-group@0.0.7":
+    resolution:
+      {
+        integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==,
+      }
+    engines: { node: ">=16" }
+    peerDependencies:
+      "@solana/web3.js": ^1.95.3
+
   "@solana/spl-token-metadata@0.1.6":
     resolution:
       {
@@ -1079,6 +1094,15 @@ packages:
     engines: { node: ">=16" }
     peerDependencies:
       "@solana/web3.js": ^1.88.0
+
+  "@solana/spl-token@0.4.9":
+    resolution:
+      {
+        integrity: sha512-g3wbj4F4gq82YQlwqhPB0gHFXfgsC6UmyGMxtSLf/BozT/oKd59465DbnlUK8L8EcimKMavxsVAMoLcEdeCicg==,
+      }
+    engines: { node: ">=16" }
+    peerDependencies:
+      "@solana/web3.js": ^1.95.3
 
   "@solana/web3.js@1.95.3":
     resolution:
@@ -5307,6 +5331,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  "@solana/spl-token-group@0.0.7(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)":
+    dependencies:
+      "@solana/codecs": 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      "@solana/web3.js": 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
   "@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)":
     dependencies:
       "@solana/codecs": 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
@@ -5319,6 +5351,21 @@ snapshots:
     dependencies:
       "@solana/buffer-layout": 4.0.1
       "@solana/buffer-layout-utils": 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      "@solana/spl-token-metadata": 0.1.6(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      "@solana/web3.js": 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  "@solana/spl-token@0.4.9(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)":
+    dependencies:
+      "@solana/buffer-layout": 4.0.1
+      "@solana/buffer-layout-utils": 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      "@solana/spl-token-group": 0.0.7(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       "@solana/spl-token-metadata": 0.1.6(@solana/web3.js@1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       "@solana/web3.js": 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       buffer: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ catalogs:
     typescript:
       specifier: 5.5.4
       version: 5.5.4
-    viem:
-      specifier: 2.16.2
-      version: 2.16.2
     yargs:
       specifier: 17.7.2
       version: 17.7.2
@@ -156,9 +153,6 @@ importers:
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
-      joi:
-        specifier: ^17.13.3
-        version: 17.13.3
       yaml:
         specifier: ^2.6.1
         version: 2.6.1
@@ -689,18 +683,6 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@hapi/hoek@9.3.0":
-    resolution:
-      {
-        integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
-      }
-
-  "@hapi/topo@5.1.0":
-    resolution:
-      {
-        integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
-      }
-
   "@humanwhocodes/config-array@0.13.0":
     resolution:
       {
@@ -994,24 +976,6 @@ packages:
     resolution:
       {
         integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==,
-      }
-
-  "@sideway/address@4.1.5":
-    resolution:
-      {
-        integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
-      }
-
-  "@sideway/formula@3.0.1":
-    resolution:
-      {
-        integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
-      }
-
-  "@sideway/pinpoint@2.0.0":
-    resolution:
-      {
-        integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
       }
 
   "@sinonjs/commons@1.8.6":
@@ -3137,12 +3101,6 @@ packages:
       node-notifier:
         optional: true
 
-  joi@17.13.3:
-    resolution:
-      {
-        integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==,
-      }
-
   js-sha256@0.9.0:
     resolution:
       {
@@ -4922,12 +4880,6 @@ snapshots:
 
   "@fastify/busboy@2.1.1": {}
 
-  "@hapi/hoek@9.3.0": {}
-
-  "@hapi/topo@5.1.0":
-    dependencies:
-      "@hapi/hoek": 9.3.0
-
   "@humanwhocodes/config-array@0.13.0":
     dependencies:
       "@humanwhocodes/object-schema": 2.0.3
@@ -5277,14 +5229,6 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.3.2
       "@scure/base": 1.1.9
-
-  "@sideway/address@4.1.5":
-    dependencies:
-      "@hapi/hoek": 9.3.0
-
-  "@sideway/formula@3.0.1": {}
-
-  "@sideway/pinpoint@2.0.0": {}
 
   "@sinonjs/commons@1.8.6":
     dependencies:
@@ -6875,14 +6819,6 @@ snapshots:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  joi@17.13.3:
-    dependencies:
-      "@hapi/hoek": 9.3.0
-      "@hapi/topo": 5.1.0
-      "@sideway/address": 4.1.5
-      "@sideway/formula": 3.0.1
-      "@sideway/pinpoint": 2.0.0
 
   js-sha256@0.9.0: {}
 

--- a/scripts/limonade/README.md
+++ b/scripts/limonade/README.md
@@ -14,3 +14,9 @@ npm run limonade -- \
 --api-key <API_KEY_FOR_LIMO_PROFILE> \
 --rpc-endpoint <RPC_URL>
 ```
+
+## Using Hermes prices
+
+Limonade can use Hermes prices to only submit opportunities that are likely to be executed against (because their implied price is close to the current market price of the pair). This is done with the optional `--price-config` argument that takes in the path to a `price-config.yaml` with the assets whose prices you want subscribe to.
+
+Please see `price-config.sample.yaml` for a sample config. The `id` field corresponds to the [Pyth Price Feed Id](https://www.pyth.network/developers/price-feed-ids) of the asset and the `mint` is simply the SPL mint of the token.

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -25,6 +25,7 @@
     "@kamino-finance/limo-sdk": "catalog:",
     "@pythnetwork/express-relay-js": "workspace:*",
     "@pythnetwork/hermes-client": "^1.2.0",
+    "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "catalog:",
     "axios": "^1.7.3",
     "bs58": "^6.0.0",

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -16,17 +16,20 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/yargs": "catalog:",
-    "typescript": "catalog:",
-    "jest": "catalog:"
+    "jest": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@coral-xyz/anchor": "catalog:",
     "@coral-xyz/anchor-cli": "catalog:",
     "@kamino-finance/limo-sdk": "catalog:",
     "@pythnetwork/express-relay-js": "workspace:*",
+    "@pythnetwork/hermes-client": "^1.2.0",
     "@solana/web3.js": "catalog:",
     "axios": "^1.7.3",
     "bs58": "^6.0.0",
+    "joi": "^17.13.3",
+    "yaml": "^2.6.1",
     "yargs": "catalog:"
   }
 }

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -28,7 +28,6 @@
     "@solana/web3.js": "catalog:",
     "axios": "^1.7.3",
     "bs58": "^6.0.0",
-    "joi": "^17.13.3",
     "yaml": "^2.6.1",
     "yargs": "catalog:"
   }

--- a/scripts/limonade/package.json
+++ b/scripts/limonade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limonade",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "This script is used to submit new opportunities fetched from the limo program to the express relay.",
   "main": "index.js",
   "scripts": {

--- a/scripts/limonade/price-config.sample.yaml
+++ b/scripts/limonade/price-config.sample.yaml
@@ -1,0 +1,6 @@
+- alias: SOL
+  mint: So11111111111111111111111111111111111111112
+  id: ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d
+- alias: USDC
+  mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  id: eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a

--- a/scripts/limonade/price-config.yaml
+++ b/scripts/limonade/price-config.yaml
@@ -1,0 +1,6 @@
+- alias: SOL
+  mint: So11111111111111111111111111111111111111112
+  id: ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d
+- alias: USDC
+  mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  id: eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a

--- a/scripts/limonade/price-config.yaml
+++ b/scripts/limonade/price-config.yaml
@@ -1,6 +1,0 @@
-- alias: SOL
-  mint: So11111111111111111111111111111111111111112
-  id: ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d
-- alias: USDC
-  mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-  id: eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -122,6 +122,7 @@ async function run() {
       filters,
       withContext: true,
     });
+    console.log("Found ", response.value.length, " orders");
 
     const payloads: OpportunityCreate[] = response.value
       .filter(
@@ -142,11 +143,6 @@ async function run() {
         (opportunityCreate) =>
           opportunityCreate.order.state.remainingInputAmount.toNumber() !== 0
       )
-      // .filter((opportunityCreate) =>
-      //   opportunityCreate.order.address.equals(
-      //     new PublicKey("FcrkTHX99fPokp5CtJzHp5MmvujFnnip57C78TLiaryj")
-      //   )
-      // )
       .filter((opportunityCreate) => !isOffMarket(opportunityCreate.order));
 
     console.log("Resubmitting opportunities", payloads.length);

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -74,11 +74,11 @@ const argv = yargs(hideBin(process.argv))
     type: "string",
     default: "https://hermes.pyth.network/",
   })
-  .option("off-market-threshold", {
+  .option("active-opportunity-price-band", {
     description:
-      "Threshold of price ratio to consider an opportunity off-market",
+      "Number of basis points an opportunity's implied price needs to be within the price from Hermes for the opportunity to be considered active",
     type: "number",
-    default: 1.05,
+    default: 500,
   })
   .option("price-staleness-threshold", {
     description:
@@ -199,7 +199,7 @@ async function run() {
             priceInputMint.mintDecimals -
             priceOutputMint.mintDecimals);
 
-      if (ratio > argv.offMarketThreshold) {
+      if (ratio > 1 + argv.activeOpportunityPriceBand / 10000) {
         return true;
       }
 

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -80,7 +80,7 @@ const argv = yargs(hideBin(process.argv))
   })
   .option("price-staleness-threshold", {
     description:
-      "Threshold of price staleness in seconds, if price is stale, we will not use it",
+      "Threshold of price staleness (seconds), if price is stale, we will not use it",
     type: "number",
     default: 10,
   })

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -180,6 +180,7 @@ async function run() {
     const priceOutputMint = priceStore[order.state.outputMint.toString()];
 
     if (!priceInputMint || !priceOutputMint) {
+      // If we don't have price info, we will not consider it off-market
       return false;
     } else {
       const inputAmount = order.state.remainingInputAmount;
@@ -275,6 +276,10 @@ async function run() {
         ignoreInvalidPriceIds: true,
       }
     );
+
+    eventSource.onerror = (event: Event) => {
+      console.error("Hermes streaming error", event);
+    };
 
     /// Await for the first message before continuing
     await new Promise<void>((resolve, reject) => {

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -144,6 +144,11 @@ async function run() {
       console.error("Failed to submit opportunity", e);
     }
   };
+  const setHermesConnectionTimeout = () => {
+    return setTimeout(() => {
+      throw new Error("Hermes streaming timeout");
+    }, argv.hermesStreamingTimeout);
+  };
   const submitExistingOpportunities = async () => {
     const response = await connection.getProgramAccounts(limoId, {
       commitment: "confirmed",
@@ -305,9 +310,7 @@ async function run() {
       console.error("Hermes streaming error", event);
     };
 
-    let hermesConnectionTimeout: NodeJS.Timeout = setTimeout(() => {
-      throw new Error("Hermes streaming failed to start");
-    }, argv.hermesStreamingTimeout);
+    let hermesConnectionTimeout: NodeJS.Timeout = setHermesConnectionTimeout();
 
     // Await for the first message before continuing
     await new Promise<void>((resolve) => {
@@ -338,9 +341,7 @@ async function run() {
         }
 
         resolve();
-        hermesConnectionTimeout = setTimeout(() => {
-          throw new Error("Hermes streaming timeout");
-        }, argv.hermesStreamingTimeout);
+        hermesConnectionTimeout = setHermesConnectionTimeout();
       };
     });
   }

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -58,6 +58,11 @@ const argv = yargs(hideBin(process.argv))
     type: "number",
     default: 30 * 1000,
   })
+  .option("hermes-streaming-timeout", {
+    description: "Hermes streaming timeout (milliseconds)",
+    type: "number",
+    default: 10 * 1000,
+  })
   .option("price-config", {
     description: "Path to the price config file",
     type: "string",
@@ -83,6 +88,7 @@ async function run() {
   const globalConfig = new PublicKey(argv.globalConfig);
   const numberOfConcurrentSubmissions = argv.numberOfConcurrentSubmissions;
   let solanaConnectionTimeout: NodeJS.Timeout | undefined;
+  let hermesConnectionTimeout: NodeJS.Timeout | undefined;
 
   const priceConfigs: PriceConfig[] = argv.priceConfig
     ? await loadPriceConfig(argv.priceConfig, connection)
@@ -269,6 +275,14 @@ async function run() {
         }
       }
     }
+
+    if (hermesConnectionTimeout !== undefined) {
+      clearTimeout(hermesConnectionTimeout);
+    }
+
+    hermesConnectionTimeout = setTimeout(() => {
+      throw new Error("Hermes streaming timeout");
+    }, argv.hermesStreamingTimeout);
   };
 
   const resubmitOpportunities = async () => {

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -293,10 +293,9 @@ async function run() {
         resolve();
 
         const data: PriceUpdate = JSON.parse(event.data);
-        const parsed = data.parsed;
         const now = Date.now();
-        if (parsed) {
-          for (const parsedUpdate of parsed) {
+        if (data.parsed) {
+          for (const parsedUpdate of data.parsed) {
             const priceConfig = priceConfigs.find(
               (priceConfig) => priceConfig.pythFeedId === parsedUpdate.id
             );

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "@pythnetwork/express-relay-js";
 import { getPdaAuthority } from "@kamino-finance/limo-sdk/dist/utils";
 import { HermesClient, PriceUpdate } from "@pythnetwork/hermes-client";
-import { PriceConfig, readPriceConfigFile } from "./price-config";
+import { PriceConfig, loadPriceConfig } from "./price-config";
 import { BN } from "@coral-xyz/anchor";
 
 const lastChange: Record<string, number> = {};
@@ -68,7 +68,7 @@ const argv = yargs(hideBin(process.argv))
     default: "https://hermes.pyth.network/",
   })
   .option("off-market-threshold", {
-    description: "Threshold for off market opportunities",
+    description: "Threshold of price ratio to consider an opportunity off-market",
     type: "number",
     default: 1.05,
   })
@@ -85,7 +85,7 @@ async function run() {
   let solanaConnectionTimeout: NodeJS.Timeout | undefined;
 
   const priceConfigs: PriceConfig[] = argv.priceConfig
-    ? readPriceConfigFile(argv.priceConfig)
+    ? await loadPriceConfig(argv.priceConfig, connection)
     : [];
 
   const filters: GetProgramAccountsFilter[] = [

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -86,6 +86,12 @@ const argv = yargs(hideBin(process.argv))
     type: "number",
     default: 10 * 1000,
   })
+  .option("resubmission-interval", {
+    description:
+      "Interval of resubmission (milliseconds). We will resubmit all existing active opportunities every interval",
+    type: "number",
+    default: 50 * 1000,
+  })
   .help()
   .alias("help", "h")
   .parseSync();
@@ -300,7 +306,7 @@ async function run() {
       console.error("Hermes streaming error", event);
     };
 
-    /// Await for the first message before continuing
+    // Await for the first message before continuing
     await new Promise<void>((resolve, reject) => {
       setTimeout(() => {
         reject(new Error("Hermes streaming timeout"));
@@ -349,7 +355,9 @@ async function run() {
       submitExistingOpportunities().catch(console.error);
       // Server expires opportunities after 2 minutes
       // We should resubmit them before server expire them to avoid creating a new row in the database
-      await new Promise((resolve) => setTimeout(resolve, 50 * 1000));
+      await new Promise((resolve) =>
+        setTimeout(resolve, argv.resubmissionInterval)
+      );
     }
   };
 

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -304,12 +304,18 @@ async function run() {
               (priceConfig) => priceConfig.pythFeedId === parsedUpdate.id
             );
             if (priceConfig) {
-              priceStore[priceConfig.mint.toString()] = {
-                price: parsedUpdate.price.price,
-                exponent: parsedUpdate.price.expo,
-                mintDecimals: priceConfig.decimals,
-                publishTime: parsedUpdate.price.publish_time,
-              };
+              const currentPrice = priceStore[priceConfig.mint.toString()];
+              if (
+                currentPrice === undefined ||
+                parsedUpdate.price.publish_time > currentPrice.publishTime
+              ) {
+                priceStore[priceConfig.mint.toString()] = {
+                  price: parsedUpdate.price.price,
+                  exponent: parsedUpdate.price.expo,
+                  mintDecimals: priceConfig.decimals,
+                  publishTime: parsedUpdate.price.publish_time,
+                };
+              }
             }
           }
         }

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -65,7 +65,8 @@ const argv = yargs(hideBin(process.argv))
     default: 5 * 1000,
   })
   .option("price-config", {
-    description: "Path to the price config file",
+    description:
+      "Path to the price config file, if not provided, we will not get price info from Hermes",
     type: "string",
   })
   .option("hermes-endpoint", {

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -186,7 +186,13 @@ async function run() {
     const priceInputMint = priceStore[order.state.inputMint.toString()];
     const priceOutputMint = priceStore[order.state.outputMint.toString()];
 
-    if (!priceInputMint || !priceOutputMint) {
+    const now = Date.now();
+    if (
+      !priceInputMint ||
+      !priceOutputMint ||
+      now - priceInputMint.publishTime * 1000 > argv.priceStalenessThreshold ||
+      now - priceOutputMint.publishTime * 1000 > argv.priceStalenessThreshold
+    ) {
       // If we don't have price info, we will not consider it off-market
       return false;
     } else {
@@ -281,6 +287,7 @@ async function run() {
         encoding: "hex",
         parsed: true,
         ignoreInvalidPriceIds: true,
+        allowUnordered: true,
       }
     );
 

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -8,6 +8,7 @@ import bs58 from "bs58";
 import { hideBin } from "yargs/helpers";
 import yargs from "yargs";
 import {
+  ChainType,
   Client,
   ClientError,
   OpportunityCreate,
@@ -15,7 +16,6 @@ import {
 import { getPdaAuthority } from "@kamino-finance/limo-sdk/dist/utils";
 import { HermesClient, PriceUpdate } from "@pythnetwork/hermes-client";
 import { PriceConfig, loadPriceConfig } from "./price-config";
-import { BN } from "@coral-xyz/anchor";
 
 const lastChange: Record<string, number> = {};
 
@@ -166,7 +166,7 @@ async function run() {
       await Promise.all(
         batch.map(async (payload) => {
           try {
-            // await client.submitOpportunity(payload);
+            await client.submitOpportunity(payload);
           } catch (e) {
             handleSubmitError(e);
           }
@@ -213,13 +213,13 @@ async function run() {
           const router = getPdaAuthority(limoId, globalConfig);
 
           try {
-            // await client.removeOpportunity({
-            //   chainType: ChainType.SVM,
-            //   program: "limo",
-            //   chainId: argv.chainId,
-            //   permissionAccount: info.accountId,
-            //   router,
-            // });
+            await client.removeOpportunity({
+              chainType: ChainType.SVM,
+              program: "limo",
+              chainId: argv.chainId,
+              permissionAccount: info.accountId,
+              router,
+            });
           } catch (e) {
             console.error("Failed to remove opportunity", e);
           }
@@ -240,7 +240,7 @@ async function run() {
         };
 
         try {
-          // await client.submitOpportunity(payload);
+          await client.submitOpportunity(payload);
           lastChange[info.accountId.toBase58()] = Date.now();
         } catch (e) {
           handleSubmitError(e);
@@ -332,7 +332,7 @@ async function run() {
       submitExistingOpportunities().catch(console.error);
       // Server expires opportunities after 2 minutes
       // We should resubmit them before server expire them to avoid creating a new row in the database
-      await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
+      await new Promise((resolve) => setTimeout(resolve, 50 * 1000));
     }
   };
 

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -82,9 +82,9 @@ const argv = yargs(hideBin(process.argv))
   })
   .option("price-staleness-threshold", {
     description:
-      "Threshold of price staleness (seconds), if price is stale, we will not use it",
+      "Threshold of price staleness (milliseconds). If price for quote or base is stale, we will submit all existing opportunities, even those that are off-market",
     type: "number",
-    default: 10,
+    default: 10 * 1000,
   })
   .help()
   .alias("help", "h")
@@ -302,7 +302,7 @@ async function run() {
             if (priceConfig) {
               if (
                 parsedUpdate.price.publish_time * 1000 <
-                now - argv.priceStalenessThreshold * 1000
+                now - argv.priceStalenessThreshold
               ) {
                 console.log(
                   "The price for",

--- a/scripts/limonade/src/index.ts
+++ b/scripts/limonade/src/index.ts
@@ -47,6 +47,7 @@ const argv = yargs(hideBin(process.argv))
     description:
       "API key to authenticate with the express relay server for publishing opportunities.",
     type: "string",
+    demandOption: true,
   })
   .option("number-of-concurrent-submissions", {
     description: "Number of concurrent submissions to the express relay server",

--- a/scripts/limonade/src/price-config.ts
+++ b/scripts/limonade/src/price-config.ts
@@ -11,17 +11,30 @@ export type PriceConfig = {
   decimals: number;
 };
 
-export async function loadPriceConfig(path: string, connection: Connection): Promise<PriceConfig[]> {
-    const priceConfigs = yaml.parse(fs.readFileSync(path, "utf8"));
+export async function loadPriceConfig(
+  path: string,
+  connection: Connection
+): Promise<PriceConfig[]> {
+  const priceConfigs = yaml.parse(fs.readFileSync(path, "utf8"));
 
-    for (const priceConfig of priceConfigs){
-      priceConfig.decimals = await getMintDecimals(connection, new PublicKey(priceConfig.mint));
-    }
+  for (const priceConfig of priceConfigs) {
+    priceConfig.decimals = await getMintDecimals(
+      connection,
+      new PublicKey(priceConfig.mint)
+    );
+  }
 
-    return priceConfigs.map((priceConfig: any) => ({
+  return priceConfigs.map(
+    (priceConfig: {
+      alias: string;
+      mint: string;
+      id: string;
+      decimals: number;
+    }) => ({
       alias: priceConfig.alias,
       mint: new PublicKey(priceConfig.mint),
       pythFeedId: priceConfig.id,
       decimals: priceConfig.decimals,
-    }));
+    })
+  );
 }

--- a/scripts/limonade/src/price-config.ts
+++ b/scripts/limonade/src/price-config.ts
@@ -2,7 +2,7 @@ import { HexString } from "@pythnetwork/hermes-client";
 import { Connection, PublicKey } from "@solana/web3.js";
 import yaml from "yaml";
 import fs from "fs";
-import { getMintDecimals } from "@kamino-finance/limo-sdk/dist/utils";
+import { getMint } from "@solana/spl-token";
 
 export type PriceConfig = {
   alias: string;
@@ -37,4 +37,12 @@ export async function loadPriceConfig(
       decimals: priceConfig.decimals,
     })
   );
+}
+
+async function getMintDecimals(
+  connection: Connection,
+  mint: PublicKey
+): Promise<number> {
+  const info = await getMint(connection, mint);
+  return info.decimals;
 }

--- a/scripts/limonade/src/price-config.ts
+++ b/scripts/limonade/src/price-config.ts
@@ -1,0 +1,24 @@
+import { HexString } from "@pythnetwork/hermes-client";
+import { PublicKey } from "@solana/web3.js";
+import yaml from "yaml";
+import fs from "fs";
+
+export type PriceConfig = {
+  alias: string;
+  mint: PublicKey;
+  pythFeedId: HexString;
+};
+
+export function readPriceConfigFile(path: string): PriceConfig[] {
+  try {
+    const priceConfigs = yaml.parse(fs.readFileSync(path, "utf8"));
+    return priceConfigs.map((priceConfig: any) => ({
+      alias: priceConfig.alias,
+      mint: new PublicKey(priceConfig.mint),
+      pythFeedId: priceConfig.id,
+    }));
+  } catch (error) {
+    console.error(`Error reading price config file ${path}: ${error}`);
+    throw error;
+  }
+}

--- a/scripts/limonade/src/price-config.ts
+++ b/scripts/limonade/src/price-config.ts
@@ -7,6 +7,7 @@ export type PriceConfig = {
   alias: string;
   mint: PublicKey;
   pythFeedId: HexString;
+  decimals: number;
 };
 
 export function readPriceConfigFile(path: string): PriceConfig[] {
@@ -16,6 +17,7 @@ export function readPriceConfigFile(path: string): PriceConfig[] {
       alias: priceConfig.alias,
       mint: new PublicKey(priceConfig.mint),
       pythFeedId: priceConfig.id,
+      decimals: priceConfig.decimals,
     }));
   } catch (error) {
     console.error(`Error reading price config file ${path}: ${error}`);

--- a/scripts/limonade/src/price-config.ts
+++ b/scripts/limonade/src/price-config.ts
@@ -18,7 +18,6 @@ export async function loadPriceConfig(path: string, connection: Connection): Pro
       priceConfig.decimals = await getMintDecimals(connection, new PublicKey(priceConfig.mint));
     }
 
-    console.log(priceConfigs)
     return priceConfigs.map((priceConfig: any) => ({
       alias: priceConfig.alias,
       mint: new PublicKey(priceConfig.mint),


### PR DESCRIPTION
This pull request adds some logic to limonade to ignore orders that are out-of-money. With a 5% threshold, if currently reduces the amount of orders to submit from 200 to 50. 

Features:
- If no `price-config` is provided it will just revert to the old behavior of submitting everything
- If `price-config` is provided it will crash if the hermes streaming is interrupted or times out. This is so kubernetes restarts limonade.
- If no price is available for `quote` or `base` (because one of the two is not listed in `price-config.yaml`  or because the price from Hermes is stale), it will revert to the old behavior of submitting all opportunities