### PR TITLE
fix: sdk to not swallow errors

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/per/tree/main/sdk/js",
   "author": "Douro Labs",

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -434,7 +434,7 @@ export class Client {
     });
     if (response.error) {
       throw ClientError.newHttpError(
-        response.error.error,
+        JSON.stringify(response.error),
         response.response.status
       );
     }
@@ -503,7 +503,7 @@ export class Client {
       });
       if (response.error) {
         throw ClientError.newHttpError(
-          response.error.error,
+          JSON.stringify(response.error),
           response.response.status
         );
       } else if (response.data === undefined) {
@@ -526,7 +526,7 @@ export class Client {
     });
     if (response.error) {
       throw ClientError.newHttpError(
-        response.error.error,
+        JSON.stringify(response.error),
         response.response.status
       );
     } else if (response.data === undefined) {

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -379,12 +379,12 @@ export class Client {
         encoded_order,
         Order.discriminator.length
       );
-      const remainingOutputAmount = anchor.BN.max(
+      const remainingOutputAmount =
         opportunity.order.state.expectedOutputAmount.sub(
           opportunity.order.state.filledOutputAmount
-        ),
-        new anchor.BN(0)
-      );
+        );
+      // new anchor.BN(0)
+
       body = {
         chain_id: opportunity.chainId,
         version: "v1" as const,
@@ -434,7 +434,7 @@ export class Client {
     });
     if (response.error) {
       throw ClientError.newHttpError(
-        response.error.error,
+        response.error.toString(),
         response.response.status
       );
     }

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -379,12 +379,12 @@ export class Client {
         encoded_order,
         Order.discriminator.length
       );
-      const remainingOutputAmount =
+      const remainingOutputAmount = anchor.BN.max(
         opportunity.order.state.expectedOutputAmount.sub(
           opportunity.order.state.filledOutputAmount
-        );
-      // new anchor.BN(0)
-
+        ),
+        new anchor.BN(0)
+      );
       body = {
         chain_id: opportunity.chainId,
         version: "v1" as const,
@@ -434,7 +434,7 @@ export class Client {
     });
     if (response.error) {
       throw ClientError.newHttpError(
-        response.error.toString(),
+        response.error.error,
         response.response.status
       );
     }
@@ -467,7 +467,7 @@ export class Client {
     });
     if (response.error) {
       throw ClientError.newHttpError(
-        response.error.error,
+        JSON.stringify(response.error),
         response.response.status
       );
     }
@@ -549,6 +549,7 @@ export class Client {
 
     return {
       chain_id: bid.chainId,
+      slot: bid.slot,
       transaction: bid.transaction
         .serialize({ requireAllSignatures: false })
         .toString("base64"),


### PR DESCRIPTION
This PR aims at fixing the sdk swallowing some auction server error messages like the 422 we saw on Tuesday last week:
before: 
`ClientError: Auction server http error 422 - undefined`
after:
`ClientError: Auction server http error 422 - "Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum OpportunityCreate"`