### PR TITLE
feat: increase slippage threshold slower and until a higher max

### DIFF
--- a/scripts/swap-beacon/package.json
+++ b/scripts/swap-beacon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swap-beacon",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/scripts/swap-beacon/src/adapter/odos.ts
+++ b/scripts/swap-beacon/src/adapter/odos.ts
@@ -62,7 +62,8 @@ export class OdosAdapter implements Adapter {
     }
 
     const swapAdapterConfig = getSwapAdapterConfig(chainId);
-    for (let threshold = 1; threshold <= 8; threshold *= 2) {
+    // handle up to 10% slippage
+    for (let threshold = 1; threshold <= 20; threshold += 1) {
       let estimatedAmountIn =
         amountIn ??
         (await this.estimateAmountIn(


### PR DESCRIPTION
For illiquid tokens there can be over %5 slippage on AMMs and the previous max was just 8 * 0.005 = %4. Also the doubling method, skipped from %4 to %8 which can cause the sell tokens to become larger than buy tokens easily, So changed it to linear scaling.