### PR TITLE
fix: remove opportunity bug

### DIFF
--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -63,8 +63,10 @@ pub struct OpportunityBidResult {
 #[derive(Serialize, Deserialize, ToSchema, Clone, PartialEq, Debug, Display)]
 pub enum ProgramSvm {
     #[strum(serialize = "swap_kamino")]
+    #[serde(rename = "swap_kamino")]
     SwapKamino,
     #[strum(serialize = "limo")]
+    #[serde(rename = "limo")]
     Limo,
 }
 

--- a/contracts/svm/programs/express_relay/src/lib.rs
+++ b/contracts/svm/programs/express_relay/src/lib.rs
@@ -282,7 +282,7 @@ pub struct SetRouterSplit<'info> {
 #[derive(AnchorSerialize, AnchorDeserialize, Eq, PartialEq, Clone, Copy, Debug)]
 pub struct SubmitBidArgs {
     // deadline as a unix timestamp in seconds
-    pub deadline:   i64, 
+    pub deadline:   i64,
     pub bid_amount: u64,
 }
 


### PR DESCRIPTION
The Python sdk expects the `OpportunityDelete` to contains limo (no caps). 
This was making the testing searcher crash.