### PR TITLE
fix: run workspace precommit only when rust files are touched

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,14 @@ repos:
         language: "rust"
         entry: cargo +nightly-2024-12-03 fmt --manifest-path ./Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
+        types_or: ["rust", "cargo", "cargo-lock"]
         files: .
       - id: cargo-clippy-workspace
         name: Cargo clippy for workspace
         language: "rust"
         entry: cargo +stable clippy --manifest-path ./Cargo.toml --tests -- -D warnings
         pass_filenames: false
+        types_or: ["rust", "cargo", "cargo-lock"]
         files: .
       # Hooks for contracts-svm
       - id: cargo-fmt-contracts-svm

--- a/sdk/python/express_relay/client.py
+++ b/sdk/python/express_relay/client.py
@@ -19,9 +19,6 @@ from hexbytes import HexBytes
 from solders.instruction import Instruction
 from solders.pubkey import Pubkey
 from solders.sysvar import INSTRUCTIONS
-
-
-
 from websockets.client import WebSocketClientProtocol
 
 from express_relay.constants import (
@@ -30,7 +27,6 @@ from express_relay.constants import (
     SVM_CONFIGS,
 )
 from express_relay.models.evm import (
-
     Address,
     Bytes32,
     TokenAmount,

--- a/sdk/python/express_relay/client.py
+++ b/sdk/python/express_relay/client.py
@@ -19,6 +19,9 @@ from hexbytes import HexBytes
 from solders.instruction import Instruction
 from solders.pubkey import Pubkey
 from solders.sysvar import INSTRUCTIONS
+
+
+
 from websockets.client import WebSocketClientProtocol
 
 from express_relay.constants import (
@@ -27,6 +30,7 @@ from express_relay.constants import (
     SVM_CONFIGS,
 )
 from express_relay.models.evm import (
+
     Address,
     Bytes32,
     TokenAmount,


### PR DESCRIPTION
This pre-commit is slow and awkward, we only need to run when something actually changes