### PR TITLE
fix migration permission key svm

### DIFF
--- a/auction-server/migrations/20250110093007_permission_key_svm_discriminator.down.sql
+++ b/auction-server/migrations/20250110093007_permission_key_svm_discriminator.down.sql
@@ -1,0 +1,11 @@
+UPDATE bid
+SET permission_key = SUBSTRING(permission_key FROM 2)
+WHERE chain_type = 'svm';
+
+UPDATE auction
+SET permission_key = SUBSTRING(permission_key FROM 2)
+WHERE chain_id = 'svm';
+
+UPDATE opportunity
+SET permission_key = SUBSTRING(permission_key FROM 2)
+WHERE chain_id = 'svm';

--- a/auction-server/migrations/20250110093007_permission_key_svm_discriminator.up.sql
+++ b/auction-server/migrations/20250110093007_permission_key_svm_discriminator.up.sql
@@ -1,0 +1,11 @@
+UPDATE bid
+SET permission_key = BYTEA '\x00' || permission_key
+WHERE chain_type = 'svm';
+
+UPDATE auction
+SET permission_key = BYTEA '\x00' || permission_key
+WHERE chain_id = 'svm';
+
+UPDATE opportunity
+SET permission_key = BYTEA '\x00' || permission_key
+WHERE chain_id = 'svm';


### PR DESCRIPTION
This PR fixes the mismatch btwn the database permission key format and the server permission key format for chain_type `svm`, which was introduced by changes in #315 