### PR TITLE
fix: add sdk paths to tilt-scripts dockerfile

### DIFF
--- a/tilt-scripts/Dockerfile
+++ b/tilt-scripts/Dockerfile
@@ -55,7 +55,7 @@ ENV PATH="$POETRY_HOME/bin:$PATH"
 
 # Copy only requirements to cache them in docker layer
 WORKDIR /src
-COPY tilt-scripts/poetry.lock tilt-scripts/pyproject.toml /src/tilt-scripts/
+COPY tilt-scripts/poetry.lock tilt-scripts/pyproject.toml sdk/python/poetry.lock sdk/python/pyproject.toml /src/tilt-scripts/
 COPY --from=contract_build /src/contracts/evm/out/ /src/contracts/evm/out/
 
 # Project initialization:
@@ -63,3 +63,4 @@ RUN poetry -C tilt-scripts install  --no-interaction --no-ansi
 
 # Creating folders, and files for a project:
 COPY tilt-scripts/ /src/tilt-scripts
+COPY sdk/python/ /src/sdk/python


### PR DESCRIPTION
since https://github.com/pyth-network/per/pull/314, tilt-scripts depends on the svm python sdk, so we need to include it in the docker build