### PR TITLE
test: more program tests

### DIFF
--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -36,16 +36,17 @@ pub fn create_swap_instruction(
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
     mint_output: Pubkey,
+    mint_fee_override: Option<Pubkey>,
     token_program_input: Option<Pubkey>,
     token_program_output: Option<Pubkey>,
     swap_args: SwapArgs,
 ) -> Instruction {
     let express_relay_metadata = get_express_relay_metadata_key();
 
-    let mint_fee = match swap_args.fee_token {
+    let mint_fee = mint_fee_override.unwrap_or(match swap_args.fee_token {
         FeeToken::Input => mint_input,
         FeeToken::Output => mint_output,
-    };
+    });
 
     let token_program_input = token_program_input.unwrap_or(spl_token::ID);
     let token_program_output = token_program_output.unwrap_or(spl_token::ID);
@@ -122,6 +123,7 @@ pub fn build_swap_instructions(
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
     mint_output: Pubkey,
+    mint_fee_override: Option<Pubkey>,
     token_program_input: Option<Pubkey>,
     token_program_output: Option<Pubkey>,
     swap_args: SwapArgs,
@@ -130,10 +132,10 @@ pub fn build_swap_instructions(
 
     let token_program_input = token_program_input.unwrap_or(spl_token::ID);
     let token_program_output = token_program_output.unwrap_or(spl_token::ID);
-    let mint_fee = match swap_args.fee_token {
+    let mint_fee = mint_fee_override.unwrap_or(match swap_args.fee_token {
         FeeToken::Input => mint_input,
         FeeToken::Output => mint_output,
-    };
+    });
     let token_program_fee = match swap_args.fee_token {
         FeeToken::Input => token_program_input,
         FeeToken::Output => token_program_output,
@@ -177,6 +179,7 @@ pub fn build_swap_instructions(
         fee_receiver_relayer,
         mint_input,
         mint_output,
+        mint_fee_override,
         Some(token_program_input),
         Some(token_program_output),
         swap_args,

--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -31,15 +31,15 @@ pub fn create_swap_instruction(
     trader: Pubkey,
     searcher_input_ta: Option<Pubkey>,
     searcher_output_ta: Option<Pubkey>,
-    trader_output_ata_override: Option<Pubkey>,
     router_fee_receiver_ta: Pubkey,
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
     mint_output: Pubkey,
-    mint_fee_override: Option<Pubkey>,
     token_program_input: Option<Pubkey>,
     token_program_output: Option<Pubkey>,
     swap_args: SwapArgs,
+    trader_output_ata_override: Option<Pubkey>,
+    mint_fee_override: Option<Pubkey>,
 ) -> Instruction {
     let express_relay_metadata = get_express_relay_metadata_key();
 
@@ -118,15 +118,15 @@ pub fn build_swap_instructions(
     trader: Pubkey,
     searcher_input_ta: Option<Pubkey>,
     searcher_output_ta: Option<Pubkey>,
-    trader_output_ata_override: Option<Pubkey>,
     router_fee_receiver_ta: Pubkey,
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
     mint_output: Pubkey,
-    mint_fee_override: Option<Pubkey>,
     token_program_input: Option<Pubkey>,
     token_program_output: Option<Pubkey>,
     swap_args: SwapArgs,
+    trader_output_ata_override: Option<Pubkey>,
+    mint_fee_override: Option<Pubkey>,
 ) -> Vec<Instruction> {
     let mut instructions: Vec<Instruction> = vec![];
 
@@ -174,15 +174,15 @@ pub fn build_swap_instructions(
         trader,
         searcher_input_ta,
         searcher_output_ta,
-        trader_output_ata_override,
         router_fee_receiver_ta,
         fee_receiver_relayer,
         mint_input,
         mint_output,
-        mint_fee_override,
         Some(token_program_input),
         Some(token_program_output),
         swap_args,
+        trader_output_ata_override,
+        mint_fee_override,
     ));
 
     instructions

--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -179,3 +179,4 @@ pub fn build_swap_instructions(
 
     instructions
 }
+

--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -179,4 +179,3 @@ pub fn build_swap_instructions(
 
     instructions
 }
-

--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -25,6 +25,8 @@ use {
     },
 };
 
+/// Builds a swap instruction.
+/// If provides two overrides, `trader_output_ata_override` and `mint_fee_override`, that may result in an invalid instruction and are meant to be used for testing.
 #[allow(clippy::too_many_arguments)]
 pub fn create_swap_instruction(
     searcher: Pubkey,
@@ -112,6 +114,8 @@ pub fn create_swap_instruction(
     }
 }
 
+/// Builds a set of instructions to perform a swap, including creating the associated token accounts.
+/// If provides two overrides, `trader_output_ata_override` and `mint_fee_override`, that may result in invalid instructions and are meant to be used for testing.
 #[allow(clippy::too_many_arguments)]
 pub fn build_swap_instructions(
     searcher: Pubkey,

--- a/contracts/svm/testing/src/express_relay/swap.rs
+++ b/contracts/svm/testing/src/express_relay/swap.rs
@@ -31,6 +31,7 @@ pub fn create_swap_instruction(
     trader: Pubkey,
     searcher_input_ta: Option<Pubkey>,
     searcher_output_ta: Option<Pubkey>,
+    trader_output_ata_override: Option<Pubkey>,
     router_fee_receiver_ta: Pubkey,
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
@@ -75,10 +76,12 @@ pub fn create_swap_instruction(
             &mint_input,
             &token_program_input,
         ),
-        trader_output_ata: get_associated_token_address_with_program_id(
-            &trader,
-            &mint_output,
-            &token_program_output,
+        trader_output_ata: trader_output_ata_override.unwrap_or(
+            get_associated_token_address_with_program_id(
+                &trader,
+                &mint_output,
+                &token_program_output,
+            ),
         ),
         router_fee_receiver_ta,
         relayer_fee_receiver_ata: get_associated_token_address_with_program_id(
@@ -114,6 +117,7 @@ pub fn build_swap_instructions(
     trader: Pubkey,
     searcher_input_ta: Option<Pubkey>,
     searcher_output_ta: Option<Pubkey>,
+    trader_output_ata_override: Option<Pubkey>,
     router_fee_receiver_ta: Pubkey,
     fee_receiver_relayer: Pubkey,
     mint_input: Pubkey,
@@ -168,6 +172,7 @@ pub fn build_swap_instructions(
         trader,
         searcher_input_ta,
         searcher_output_ta,
+        trader_output_ata_override,
         router_fee_receiver_ta,
         fee_receiver_relayer,
         mint_input,

--- a/contracts/svm/testing/tests/swap.rs
+++ b/contracts/svm/testing/tests/swap.rs
@@ -358,15 +358,15 @@ fn test_swap_fee_input_token(args: SwapSetupParams) {
         trader.pubkey(),
         None,
         None,
-        None,
         router_input_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap();
 
@@ -505,15 +505,15 @@ fn test_swap_fee_output_token(args: SwapSetupParams) {
         trader.pubkey(),
         None,
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap();
 
@@ -606,15 +606,15 @@ fn test_swap_expired_deadline() {
         trader.pubkey(),
         None,
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -654,15 +654,15 @@ fn test_swap_invalid_referral_fee_bps() {
         trader.pubkey(),
         None,
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -702,15 +702,15 @@ fn test_swap_router_ta_has_wrong_mint() {
         trader.pubkey(),
         None,
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -753,15 +753,15 @@ fn test_swap_searcher_ta_wrong_mint() {
         trader.pubkey(),
         Some(third_token.get_associated_token_address(&searcher.pubkey())),
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -801,15 +801,15 @@ fn test_swap_searcher_ta_wrong_owner() {
         trader.pubkey(),
         Some(input_token.get_associated_token_address(&trader.pubkey())),
         None,
-        None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -847,15 +847,15 @@ fn test_swap_wrong_express_relay_fee_receiver() {
         trader.pubkey(),
         None,
         None,
-        None,
         router_output_ta,
         Keypair::new().pubkey(),
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -896,15 +896,15 @@ fn test_swap_trader_output_ata_is_not_ata() {
         trader.pubkey(),
         None,
         None,
-        Some(trader_output_ata),
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        None,
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        Some(trader_output_ata),
+        None,
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
@@ -944,15 +944,15 @@ fn test_swap_wrong_mint_fee() {
         trader.pubkey(),
         None,
         None,
-        None,
         router_input_ta,
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
-        Some(input_token.mint),
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
+        None,
+        Some(input_token.mint),
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();

--- a/contracts/svm/testing/tests/swap.rs
+++ b/contracts/svm/testing/tests/swap.rs
@@ -594,7 +594,7 @@ fn test_swap_expired_deadline() {
 
     // output token fee
     let swap_args = SwapArgs {
-        deadline:         svm.get_sysvar::<Clock>().unix_timestamp - 1,
+        deadline:         svm.get_sysvar::<Clock>().unix_timestamp - 1, // <--- deadline is in the past
         amount_input:     input_token.get_amount_with_decimals(1.),
         amount_output:    output_token.get_amount_with_decimals(1.),
         referral_fee_bps: 1500,
@@ -645,7 +645,7 @@ fn test_swap_invalid_referral_fee_bps() {
         deadline:         svm.get_sysvar::<Clock>().unix_timestamp,
         amount_input:     input_token.get_amount_with_decimals(1.),
         amount_output:    output_token.get_amount_with_decimals(1.),
-        referral_fee_bps: (FEE_SPLIT_PRECISION + 1) as u16,
+        referral_fee_bps: (FEE_SPLIT_PRECISION + 1) as u16, // <--- referral fee bps is too high
         fee_token:        FeeToken::Output,
     };
 
@@ -702,7 +702,7 @@ fn test_swap_router_ta_has_wrong_mint() {
         trader.pubkey(),
         None,
         None,
-        router_output_ta,
+        router_output_ta, // <--- router should receive the input token
         express_relay_metadata.fee_receiver_relayer,
         input_token.mint,
         output_token.mint,
@@ -751,7 +751,7 @@ fn test_swap_searcher_ta_wrong_mint() {
     let instructions = build_swap_instructions(
         searcher.pubkey(),
         trader.pubkey(),
-        Some(third_token.get_associated_token_address(&searcher.pubkey())),
+        Some(third_token.get_associated_token_address(&searcher.pubkey())), // <--- searcher input ta has the wrong mint
         None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
@@ -799,7 +799,7 @@ fn test_swap_searcher_ta_wrong_owner() {
     let instructions = build_swap_instructions(
         searcher.pubkey(),
         trader.pubkey(),
-        Some(input_token.get_associated_token_address(&trader.pubkey())),
+        Some(input_token.get_associated_token_address(&trader.pubkey())), // <--- searcher input ta has the wrong owner
         None,
         router_output_ta,
         express_relay_metadata.fee_receiver_relayer,
@@ -848,7 +848,7 @@ fn test_swap_wrong_express_relay_fee_receiver() {
         None,
         None,
         router_output_ta,
-        Keypair::new().pubkey(),
+        Keypair::new().pubkey(), // <--- wrong express relay fee receiver
         input_token.mint,
         output_token.mint,
         Some(input_token.token_program),
@@ -903,7 +903,7 @@ fn test_swap_trader_output_ata_is_not_ata() {
         Some(input_token.token_program),
         Some(output_token.token_program),
         swap_args,
-        Some(trader_output_ata),
+        Some(trader_output_ata), // <--- trader output ata is not an ata
         None,
     );
     let result =
@@ -952,7 +952,7 @@ fn test_swap_wrong_mint_fee() {
         Some(output_token.token_program),
         swap_args,
         None,
-        Some(input_token.mint),
+        Some(input_token.mint), // <--- wrong mint fee
     );
     let result =
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();

--- a/contracts/svm/testing/tests/swap.rs
+++ b/contracts/svm/testing/tests/swap.rs
@@ -1,5 +1,8 @@
 use {
-    anchor_lang::{error::ErrorCode as AnchorErrorCode, AccountDeserialize},
+    anchor_lang::{
+        error::ErrorCode as AnchorErrorCode,
+        AccountDeserialize,
+    },
     anchor_spl::{
         associated_token::{
             get_associated_token_address_with_program_id,
@@ -15,7 +18,10 @@ use {
         },
     },
     express_relay::{
-        error::ErrorCode, state::FEE_SPLIT_PRECISION, FeeToken, SwapArgs
+        error::ErrorCode,
+        state::FEE_SPLIT_PRECISION,
+        FeeToken,
+        SwapArgs,
     },
     litesvm::LiteSVM,
     solana_sdk::{
@@ -696,7 +702,8 @@ fn test_swap_right() {
         Some(output_token.token_program),
         swap_args,
     );
-    let result = submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap();
+    let result =
+        submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap();
 }
 
 #[test]
@@ -764,7 +771,7 @@ fn test_swap_searcher_ta_wrong_mint() {
     });
 
     let express_relay_metadata = get_express_relay_metadata(&mut svm);
-    
+
     let third_token = Token::create_mint(&mut svm, spl_token::ID, 6);
     third_token.airdrop(&mut svm, &searcher.pubkey(), 10.);
 
@@ -813,7 +820,7 @@ fn test_swap_searcher_ta_wrong_owner() {
     });
 
     let express_relay_metadata = get_express_relay_metadata(&mut svm);
-    
+
     let swap_args = SwapArgs {
         deadline:         svm.get_sysvar::<Clock>().unix_timestamp,
         amount_input:     input_token.get_amount_with_decimals(1.),
@@ -857,7 +864,7 @@ fn test_swap_wrong_express_relay_fee_receiver() {
         output_token_program:  spl_token::ID,
         output_token_decimals: 6,
     });
-    
+
     let swap_args = SwapArgs {
         deadline:         svm.get_sysvar::<Clock>().unix_timestamp,
         amount_input:     input_token.get_amount_with_decimals(1.),
@@ -883,4 +890,3 @@ fn test_swap_wrong_express_relay_fee_receiver() {
         submit_transaction(&mut svm, &instructions, &searcher, &[&searcher, &trader]).unwrap_err();
     assert_custom_error(result.err, 4, AnchorErrorCode::ConstraintTokenOwner.into());
 }
-


### PR DESCRIPTION
- [x] using non-ATAs in places where ATAs are expected
- [x] using misconfigured token accounts (wrong mint)
- [x] using misconfigured token accounts (wrong owner)
- [x] using invalid referral fee
- [x] using invalid mint fee
- [ ] using misconfigured token accounts (wrong token program) (this one is impossible because wrong token program implies wrong mint and that check will get triggered first)