### PR TITLE
Update bid status variant order

### DIFF
--- a/auction-server/api-types/src/bid.rs
+++ b/auction-server/api-types/src/bid.rs
@@ -130,8 +130,8 @@ pub enum BidStatusSvm {
 #[derive(Serialize, Deserialize, ToSchema, Clone, PartialEq, Debug)]
 #[serde(untagged)]
 pub enum BidStatus {
-    Evm(BidStatusEvm),
     Svm(BidStatusSvm),
+    Evm(BidStatusEvm),
 }
 
 #[derive(Serialize, Deserialize, ToResponse, ToSchema, Clone)]


### PR DESCRIPTION
This PR aims to temporary fix rust sdk issue on bid status enum variant.

When the sdk receive a Lost status with No data inside, it'll assume that the variant is for EVM (Which maybe wrong). Later we need to add a tag to it for serailization.