### PR TITLE
Fix svm in memory auction issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/src/auction/service/auction_manager.rs
+++ b/auction-server/src/auction/service/auction_manager.rs
@@ -605,7 +605,7 @@ impl AuctionManager<Svm> for Service<Svm> {
     }
 
     fn is_auction_expired(auction: &entities::Auction<Svm>) -> bool {
-        auction.creation_time + BID_MAXIMUM_LIFE_TIME_SVM < OffsetDateTime::now_utc()
+        auction.creation_time + BID_MAXIMUM_LIFE_TIME_SVM * 2 < OffsetDateTime::now_utc()
     }
 }
 

--- a/auction-server/src/auction/service/conclude_auction.rs
+++ b/auction-server/src/auction/service/conclude_auction.rs
@@ -55,6 +55,18 @@ where
                     .conclude_auction(auction.id)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to conclude auction: {:?}", e))?;
+            } else if Self::is_auction_expired(&auction) {
+                // TODO This is a workaround for a bug, we need to find a better solution
+                // TODO Maybe a way to make sure bids are assigned only to one auction
+                // There are some cases where the bid for the auction is also in another auction
+                // If the other auction is concluded, the bid status for that auction is updated
+                // But the bid status for this auction is not updated and it's impossible to update it
+                // If the auction is expired, we need to remove it from the in-memory store
+                // To make sure that the auction is not stuck for ever
+                self.repo
+                    .conclude_auction(auction.id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to conclude auction: {:?}", e))?;
             }
         }
 


### PR DESCRIPTION
This PR addresses the issue of halted auctions in the in-memory auction list. While this serves as a temporary workaround, we need to find a more effective long-term solution.