### PR TITLE
tests: write actual tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "futures",
  "gas-oracle",
  "litesvm",
+ "mockall",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2126,6 +2127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,6 +2820,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs2"
@@ -4229,6 +4242,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4979,6 +5018,32 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -8287,6 +8352,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-searcher"

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -55,3 +55,6 @@ litesvm = { workspace = true }
 express-relay-api-types = { path = "api-types" }
 strum.workspace = true
 spl-associated-token-account = { workspace = true }
+
+[dev-dependencies]
+mockall = "0.13.1"

--- a/auction-server/api-types/src/bid.rs
+++ b/auction-server/api-types/src/bid.rs
@@ -320,7 +320,7 @@ pub enum BidCreate {
     Svm(BidCreateSvm),
 }
 
-#[derive(Serialize, Clone, ToSchema, ToResponse, Deserialize, Debug)]
+#[derive(Serialize, Clone, ToSchema, ToResponse, Deserialize, Debug, PartialEq)]
 pub struct BidStatusWithId {
     #[schema(value_type = String)]
     pub id:         BidId,

--- a/auction-server/api-types/src/lib.rs
+++ b/auction-server/api-types/src/lib.rs
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for PermissionKeySvm {
 }
 
 #[serde_as]
-#[derive(Serialize, Clone, ToSchema, ToResponse, Deserialize, Debug)]
+#[derive(Serialize, Clone, ToSchema, ToResponse, Deserialize, Debug, PartialEq)]
 pub struct SvmChainUpdate {
     #[schema(example = "solana", value_type = String)]
     pub chain_id:                  ChainId,

--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -268,7 +268,7 @@ pub enum OpportunityParamsEvm {
     V1(OpportunityParamsV1Evm),
 }
 
-#[derive(Serialize, Deserialize, ToSchema, Clone, ToResponse, Debug)]
+#[derive(Serialize, Deserialize, ToSchema, Clone, ToResponse, Debug, PartialEq)]
 pub struct OpportunityEvm {
     /// The opportunity unique id.
     #[schema(example = "obo3ee3e-58cc-4372-a567-0e02b2c3d479", value_type = String)]
@@ -433,7 +433,7 @@ pub struct OpportunitySvm {
     pub params: OpportunityParamsSvm,
 }
 
-#[derive(Serialize, ToResponse, ToSchema, Clone, Debug)]
+#[derive(Serialize, ToResponse, ToSchema, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum Opportunity {

--- a/auction-server/src/api/ws.rs
+++ b/auction-server/src/api/ws.rs
@@ -109,7 +109,7 @@ async fn websocket_handler(stream: WebSocket, state: Arc<StoreNew>, auth: Auth) 
     subscriber.run().await;
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum UpdateEvent {
     NewOpportunity(Opportunity),
     BidStatusUpdate(BidStatusWithId),

--- a/auction-server/src/kernel/traced_sender_svm.rs
+++ b/auction-server/src/kernel/traced_sender_svm.rs
@@ -73,3 +73,21 @@ impl TracedSenderSvm {
         RpcClient::new_sender(TracedSenderSvm { sender, chain_id }, config)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        mockall::mock,
+    };
+
+    mock!(
+        pub RpcClient {}
+        #[async_trait]
+        impl RpcSender for RpcClient {
+            async fn send(&self, request: RpcRequest, params: serde_json::Value) -> client_error::Result<serde_json::Value>;
+            fn get_transport_stats(&self) -> RpcTransportStats ;
+            fn url(&self) -> String;
+        }
+    );
+}

--- a/auction-server/src/opportunity/repository/add_opportunity.rs
+++ b/auction-server/src/opportunity/repository/add_opportunity.rs
@@ -14,14 +14,13 @@ use {
     sqlx::Postgres,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn add_opportunity(
         &self,
-        db: &sqlx::Pool<Postgres>,
         opportunity: <T::Opportunity as entities::Opportunity>::OpportunityCreate,
     ) -> Result<T::Opportunity, RestError> {
         let opportunity: T::Opportunity = T::Opportunity::new_with_current_time(opportunity);
-        OpportunityTable::<T>::add_opportunity(db, &opportunity).await?;
+        self.db.add_opportunity(&opportunity).await?;
         self.in_memory_store
             .opportunities
             .write()

--- a/auction-server/src/opportunity/repository/add_opportunity.rs
+++ b/auction-server/src/opportunity/repository/add_opportunity.rs
@@ -11,7 +11,6 @@ use {
             Opportunity,
         },
     },
-    sqlx::Postgres,
 };
 
 impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {

--- a/auction-server/src/opportunity/repository/add_opportunity.rs
+++ b/auction-server/src/opportunity/repository/add_opportunity.rs
@@ -21,8 +21,7 @@ impl<T: InMemoryStore> Repository<T> {
         db: &sqlx::Pool<Postgres>,
         opportunity: <T::Opportunity as entities::Opportunity>::OpportunityCreate,
     ) -> Result<T::Opportunity, RestError> {
-        let opportunity: T::Opportunity =
-            <T::Opportunity as entities::Opportunity>::new_with_current_time(opportunity);
+        let opportunity: T::Opportunity = T::Opportunity::new_with_current_time(opportunity);
         let metadata = opportunity.get_models_metadata();
         let chain_type = <T::Opportunity as entities::Opportunity>::ModelMetadata::get_chain_type();
         sqlx::query!("INSERT INTO opportunity (id,

--- a/auction-server/src/opportunity/repository/add_opportunity.rs
+++ b/auction-server/src/opportunity/repository/add_opportunity.rs
@@ -1,7 +1,6 @@
 use {
     super::{
         db::OpportunityTable,
-        models::OpportunityMetadata,
         InMemoryStore,
         Repository,
     },
@@ -13,7 +12,6 @@ use {
         },
     },
     sqlx::Postgres,
-    time::PrimitiveDateTime,
 };
 
 impl<T: InMemoryStore> Repository<T> {

--- a/auction-server/src/opportunity/repository/add_opportunity.rs
+++ b/auction-server/src/opportunity/repository/add_opportunity.rs
@@ -1,14 +1,15 @@
 use {
     super::{
+        db::OpportunityTable,
         models::OpportunityMetadata,
         InMemoryStore,
         Repository,
     },
     crate::{
         api::RestError,
-        opportunity::{
-            entities,
-            entities::Opportunity,
+        opportunity::entities::{
+            self,
+            Opportunity,
         },
     },
     sqlx::Postgres,
@@ -22,31 +23,7 @@ impl<T: InMemoryStore> Repository<T> {
         opportunity: <T::Opportunity as entities::Opportunity>::OpportunityCreate,
     ) -> Result<T::Opportunity, RestError> {
         let opportunity: T::Opportunity = T::Opportunity::new_with_current_time(opportunity);
-        let metadata = opportunity.get_models_metadata();
-        let chain_type = <T::Opportunity as entities::Opportunity>::ModelMetadata::get_chain_type();
-        sqlx::query!("INSERT INTO opportunity (id,
-                                                        creation_time,
-                                                        permission_key,
-                                                        chain_id,
-                                                        chain_type,
-                                                        metadata,
-                                                        sell_tokens,
-                                                        buy_tokens) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        opportunity.id,
-        PrimitiveDateTime::new(opportunity.creation_time.date(), opportunity.creation_time.time()),
-        opportunity.permission_key.to_vec(),
-        opportunity.chain_id,
-        chain_type as _,
-        serde_json::to_value(metadata).expect("Failed to serialize metadata"),
-        serde_json::to_value(&opportunity.sell_tokens).expect("Failed to serialize sell_tokens"),
-        serde_json::to_value(&opportunity.buy_tokens).expect("Failed to serialize buy_tokens"))
-            .execute(db)
-            .await
-            .map_err(|e| {
-                tracing::error!("DB: Failed to insert opportunity: {}", e);
-                RestError::TemporarilyUnavailable
-            })?;
-
+        OpportunityTable::<T>::add_opportunity(db, &opportunity).await?;
         self.in_memory_store
             .opportunities
             .write()

--- a/auction-server/src/opportunity/repository/db.rs
+++ b/auction-server/src/opportunity/repository/db.rs
@@ -36,7 +36,6 @@ pub trait OpportunityTable<T: InMemoryStore> {
         &self,
         permission_key: PermissionKey,
         chain_id: ChainId,
-        opportunity_key: &entities::OpportunityKey,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<()>;
     async fn remove_opportunity(
@@ -130,7 +129,6 @@ impl<T: InMemoryStore> OpportunityTable<T> for DB {
         &self,
         permission_key: PermissionKey,
         chain_id: ChainId,
-        opportunity_key: &entities::OpportunityKey,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<()> {
         let now = OffsetDateTime::now_utc();

--- a/auction-server/src/opportunity/repository/db.rs
+++ b/auction-server/src/opportunity/repository/db.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use mockall::automock;
 use {
     super::{
         entities,
@@ -24,6 +26,7 @@ use {
     },
 };
 
+#[cfg_attr(test, automock)]
 pub trait OpportunityTable<T: InMemoryStore> {
     async fn add_opportunity(&self, opportunity: &T::Opportunity) -> Result<(), RestError>;
     async fn get_opportunities(
@@ -40,7 +43,7 @@ pub trait OpportunityTable<T: InMemoryStore> {
     ) -> anyhow::Result<()>;
     async fn remove_opportunity(
         &self,
-        opportunity: &<T as InMemoryStore>::Opportunity,
+        opportunity: &T::Opportunity,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<()>;
 }
@@ -144,7 +147,7 @@ impl<T: InMemoryStore> OpportunityTable<T> for DB {
 
     async fn remove_opportunity(
         &self,
-        opportunity: &<T as InMemoryStore>::Opportunity,
+        opportunity: &T::Opportunity,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<()> {
         let now = OffsetDateTime::now_utc();

--- a/auction-server/src/opportunity/repository/db.rs
+++ b/auction-server/src/opportunity/repository/db.rs
@@ -1,0 +1,179 @@
+use {
+    super::{
+        entities,
+        models,
+        InMemoryStore,
+        OpportunityMetadata,
+        OpportunityRemovalReason,
+    },
+    crate::{
+        api::RestError,
+        kernel::{
+            db::DB,
+            entities::{
+                ChainId,
+                PermissionKey,
+            },
+        },
+        opportunity::entities::Opportunity,
+    },
+    sqlx::QueryBuilder,
+    time::{
+        OffsetDateTime,
+        PrimitiveDateTime,
+    },
+};
+
+const OPPORTUNITY_PAGE_SIZE_CAP: usize = 100;
+
+pub trait OpportunityTable<T: InMemoryStore> {
+    async fn add_opportunity(&self, opportunity: T::Opportunity) -> Result<(), RestError>;
+    async fn get_opportunities(
+        &self,
+        chain_id: ChainId,
+        permission_key: Option<PermissionKey>,
+        from_time: Option<OffsetDateTime>,
+    ) -> Result<Vec<T::Opportunity>, RestError>;
+    async fn remove_opportunities(
+        &self,
+        permission_key: PermissionKey,
+        chain_id: ChainId,
+        opportunity_key: &entities::OpportunityKey,
+        reason: OpportunityRemovalReason,
+    ) -> anyhow::Result<()>;
+    async fn remove_opportunity(
+        &self,
+        opportunity: &<T as InMemoryStore>::Opportunity,
+        reason: OpportunityRemovalReason,
+    ) -> anyhow::Result<()>;
+}
+
+impl<T: InMemoryStore> OpportunityTable<T> for DB {
+    async fn add_opportunity(&self, opportunity: T::Opportunity) -> Result<(), RestError> {
+        let metadata = opportunity.get_models_metadata();
+        let chain_type = <T::Opportunity as entities::Opportunity>::ModelMetadata::get_chain_type();
+        sqlx::query!("INSERT INTO opportunity (id,
+                                                        creation_time,
+                                                        permission_key,
+                                                        chain_id,
+                                                        chain_type,
+                                                        metadata,
+                                                        sell_tokens,
+                                                        buy_tokens) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        opportunity.id,
+        PrimitiveDateTime::new(opportunity.creation_time.date(), opportunity.creation_time.time()),
+        opportunity.permission_key.to_vec(),
+        opportunity.chain_id,
+        chain_type as _,
+        serde_json::to_value(metadata).expect("Failed to serialize metadata"),
+        serde_json::to_value(&opportunity.sell_tokens).expect("Failed to serialize sell_tokens"),
+        serde_json::to_value(&opportunity.buy_tokens).expect("Failed to serialize buy_tokens"))
+            .execute(self)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB: Failed to insert opportunity: {}", e);
+                RestError::TemporarilyUnavailable
+            })?;
+        Ok(())
+    }
+
+    async fn get_opportunities(
+        &self,
+        chain_id: ChainId,
+        permission_key: Option<PermissionKey>,
+        from_time: Option<OffsetDateTime>,
+    ) -> Result<Vec<<T as InMemoryStore>::Opportunity>, RestError> {
+        let mut query = QueryBuilder::new("SELECT * from opportunity WHERE chain_type = ");
+        query.push_bind(
+            <<T::Opportunity as entities::Opportunity>::ModelMetadata>::get_chain_type(),
+        );
+        query.push(" AND chain_id = ");
+        query.push_bind(chain_id.clone());
+        if let Some(permission_key) = permission_key.clone() {
+            query.push(" AND permission_key = ");
+            query.push_bind(permission_key.to_vec());
+        }
+        if let Some(from_time) = from_time {
+            query.push(" AND creation_time >= ");
+            query.push_bind(from_time);
+        }
+        query.push(" ORDER BY creation_time ASC LIMIT ");
+        query.push_bind(super::OPPORTUNITY_PAGE_SIZE_CAP as i64);
+        let opps: Vec<models::Opportunity<<T::Opportunity as entities::Opportunity>::ModelMetadata>> = query
+            .build_query_as()
+            .fetch_all(self)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "DB: Failed to fetch opportunities: {} - chain_id: {:?} - permission_key: {:?} - from_time: {:?}",
+                    e,
+                    chain_id,
+                    permission_key,
+                    from_time,
+                );
+                RestError::TemporarilyUnavailable
+            })?;
+
+        opps.into_iter().map(|opp| opp.clone().try_into().map_err(
+            |_| {
+                tracing::error!(
+                    "Failed to convert database opportunity to entity opportunity: {:?} - chain_id: {:?} - permission_key: {:?} - from_time: {:?}",
+                    opp,
+                    chain_id,
+                    permission_key,
+                    from_time,
+                );
+                RestError::TemporarilyUnavailable
+            }
+        )).collect()
+    }
+
+    async fn remove_opportunities(
+        &self,
+        permission_key: PermissionKey,
+        chain_id: ChainId,
+        opportunity_key: &entities::OpportunityKey,
+        reason: OpportunityRemovalReason,
+    ) -> anyhow::Result<()> {
+        let now = OffsetDateTime::now_utc();
+        sqlx::query("UPDATE opportunity SET removal_time = $1, removal_reason = $2 WHERE permission_key = $3 AND chain_id = $4 and removal_time IS NULL")
+            .bind(PrimitiveDateTime::new(now.date(), now.time()))
+            .bind(reason)
+            .bind(permission_key.as_ref())
+            .bind(chain_id)
+            .execute(self)
+            .await?;
+        Ok(())
+    }
+
+    async fn remove_opportunity(
+        &self,
+        opportunity: &<T as InMemoryStore>::Opportunity,
+        reason: OpportunityRemovalReason,
+    ) -> anyhow::Result<()> {
+        let now = OffsetDateTime::now_utc();
+        sqlx::query("UPDATE opportunity SET removal_time = $1, removal_reason = $2 WHERE id = $3 AND removal_time IS NULL")
+            .bind(PrimitiveDateTime::new(now.date(), now.time()))
+            .bind(reason)
+            .bind(opportunity.id)
+            .execute(self)
+            .await?;
+        Ok(())
+    }
+}
+
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::opportunity::repository::InMemoryStoreSvm;
+
+//     use super::*;
+
+//     #[tokio::test]
+//     async fn test_get_opportunities() {
+//         let mut db = MockOpportunityTable::<InMemoryStoreSvm>::default();
+//         db.expect_get_opportunities().returning(|_, _, _| Ok(vec![]));
+//         let opps = db.get_opportunities("evm".to_string(), None, None).await;
+//             println!("{:?}", opps);
+//     }
+// }

--- a/auction-server/src/opportunity/repository/db.rs
+++ b/auction-server/src/opportunity/repository/db.rs
@@ -160,19 +160,3 @@ impl<T: InMemoryStore> OpportunityTable<T> for DB {
         Ok(())
     }
 }
-
-
-// #[cfg(test)]
-// mod tests {
-//     use crate::opportunity::repository::InMemoryStoreSvm;
-
-//     use super::*;
-
-//     #[tokio::test]
-//     async fn test_get_opportunities() {
-//         let mut db = MockOpportunityTable::<InMemoryStoreSvm>::default();
-//         db.expect_get_opportunities().returning(|_, _, _| Ok(vec![]));
-//         let opps = db.get_opportunities("evm".to_string(), None, None).await;
-//             println!("{:?}", opps);
-//     }
-// }

--- a/auction-server/src/opportunity/repository/db.rs
+++ b/auction-server/src/opportunity/repository/db.rs
@@ -24,10 +24,8 @@ use {
     },
 };
 
-const OPPORTUNITY_PAGE_SIZE_CAP: usize = 100;
-
 pub trait OpportunityTable<T: InMemoryStore> {
-    async fn add_opportunity(&self, opportunity: T::Opportunity) -> Result<(), RestError>;
+    async fn add_opportunity(&self, opportunity: &T::Opportunity) -> Result<(), RestError>;
     async fn get_opportunities(
         &self,
         chain_id: ChainId,
@@ -49,7 +47,7 @@ pub trait OpportunityTable<T: InMemoryStore> {
 }
 
 impl<T: InMemoryStore> OpportunityTable<T> for DB {
-    async fn add_opportunity(&self, opportunity: T::Opportunity) -> Result<(), RestError> {
+    async fn add_opportunity(&self, opportunity: &T::Opportunity) -> Result<(), RestError> {
         let metadata = opportunity.get_models_metadata();
         let chain_type = <T::Opportunity as entities::Opportunity>::ModelMetadata::get_chain_type();
         sqlx::query!("INSERT INTO opportunity (id,

--- a/auction-server/src/opportunity/repository/get_in_memory_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_in_memory_opportunities.rs
@@ -1,13 +1,14 @@
 use {
     super::{
         InMemoryStore,
+        OpportunityTable,
         Repository,
     },
     crate::opportunity::entities,
     std::collections::HashMap,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn get_in_memory_opportunities(
         &self,
     ) -> HashMap<entities::OpportunityKey, Vec<T::Opportunity>> {

--- a/auction-server/src/opportunity/repository/get_in_memory_opportunities_by_key.rs
+++ b/auction-server/src/opportunity/repository/get_in_memory_opportunities_by_key.rs
@@ -1,12 +1,13 @@
 use {
     super::{
         InMemoryStore,
+        OpportunityTable,
         Repository,
     },
     crate::opportunity::entities,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn get_in_memory_opportunities_by_key(
         &self,
         opportunity_key: &entities::OpportunityKey,

--- a/auction-server/src/opportunity/repository/get_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_opportunities.rs
@@ -1,9 +1,6 @@
 use {
     super::{
         db::OpportunityTable,
-        models::{
-            self,
-        },
         InMemoryStore,
         Repository,
     },
@@ -13,12 +10,7 @@ use {
             ChainId,
             PermissionKey,
         },
-        opportunity::{
-            entities,
-            repository::models::OpportunityMetadata,
-        },
     },
-    sqlx::QueryBuilder,
     time::OffsetDateTime,
 };
 

--- a/auction-server/src/opportunity/repository/get_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_opportunities.rs
@@ -14,14 +14,15 @@ use {
     time::OffsetDateTime,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn get_opportunities(
         &self,
-        db: &sqlx::Pool<sqlx::Postgres>,
         chain_id: ChainId,
         permission_key: Option<PermissionKey>,
         from_time: Option<OffsetDateTime>,
     ) -> Result<Vec<T::Opportunity>, RestError> {
-        OpportunityTable::<T>::get_opportunities(db, chain_id, permission_key, from_time).await
+        self.db
+            .get_opportunities(chain_id, permission_key, from_time)
+            .await
     }
 }

--- a/auction-server/src/opportunity/repository/get_opportunities.rs
+++ b/auction-server/src/opportunity/repository/get_opportunities.rs
@@ -1,5 +1,6 @@
 use {
     super::{
+        db::OpportunityTable,
         models::{
             self,
         },
@@ -29,48 +30,6 @@ impl<T: InMemoryStore> Repository<T> {
         permission_key: Option<PermissionKey>,
         from_time: Option<OffsetDateTime>,
     ) -> Result<Vec<T::Opportunity>, RestError> {
-        let mut query = QueryBuilder::new("SELECT * from opportunity WHERE chain_type = ");
-        query.push_bind(
-            <<T::Opportunity as entities::Opportunity>::ModelMetadata>::get_chain_type(),
-        );
-        query.push(" AND chain_id = ");
-        query.push_bind(chain_id.clone());
-        if let Some(permission_key) = permission_key.clone() {
-            query.push(" AND permission_key = ");
-            query.push_bind(permission_key.to_vec());
-        }
-        if let Some(from_time) = from_time {
-            query.push(" AND creation_time >= ");
-            query.push_bind(from_time);
-        }
-        query.push(" ORDER BY creation_time ASC LIMIT ");
-        query.push_bind(super::OPPORTUNITY_PAGE_SIZE_CAP as i64);
-        let opps: Vec<models::Opportunity<<T::Opportunity as entities::Opportunity>::ModelMetadata>> = query
-            .build_query_as()
-            .fetch_all(db)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "DB: Failed to fetch opportunities: {} - chain_id: {:?} - permission_key: {:?} - from_time: {:?}",
-                    e,
-                    chain_id,
-                    permission_key,
-                    from_time,
-                );
-                RestError::TemporarilyUnavailable
-            })?;
-
-        opps.into_iter().map(|opp| opp.clone().try_into().map_err(
-            |_| {
-                tracing::error!(
-                    "Failed to convert database opportunity to entity opportunity: {:?} - chain_id: {:?} - permission_key: {:?} - from_time: {:?}",
-                    opp,
-                    chain_id,
-                    permission_key,
-                    from_time,
-                );
-                RestError::TemporarilyUnavailable
-            }
-        )).collect()
+        OpportunityTable::<T>::get_opportunities(db, chain_id, permission_key, from_time).await
     }
 }

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -12,6 +12,7 @@ use {
 
 mod add_opportunity;
 mod add_spoof_info;
+mod db;
 mod get_express_relay_metadata;
 mod get_in_memory_opportunities;
 mod get_in_memory_opportunities_by_key;

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -1,5 +1,7 @@
 use {
     super::entities,
+    crate::kernel::db::DB,
+    db::OpportunityTable,
     ethers::types::Address,
     express_relay::state::ExpressRelayMetadata,
     solana_sdk::pubkey::Pubkey,
@@ -29,8 +31,9 @@ pub use models::*;
 pub const OPPORTUNITY_PAGE_SIZE_CAP: usize = 100;
 
 #[derive(Debug)]
-pub struct Repository<T: InMemoryStore> {
+pub struct Repository<T: InMemoryStore, U: OpportunityTable<T> = DB> {
     pub in_memory_store: T,
+    pub db:              U,
 }
 
 pub trait InMemoryStore:
@@ -102,10 +105,11 @@ impl Deref for InMemoryStoreSvm {
     }
 }
 
-impl<T: InMemoryStore> Repository<T> {
-    pub fn new() -> Self {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
+    pub fn new(db: U) -> Self {
         Self {
             in_memory_store: T::new(),
+            db,
         }
     }
 }

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -1,7 +1,6 @@
 use {
     super::entities,
     crate::kernel::db::DB,
-    db::OpportunityTable,
     ethers::types::Address,
     express_relay::state::ExpressRelayMetadata,
     solana_sdk::pubkey::Pubkey,
@@ -27,7 +26,11 @@ mod refresh_in_memory_opportunity;
 mod remove_opportunities;
 mod remove_opportunity;
 
-pub use models::*;
+pub use {
+    db::OpportunityTable,
+    models::*,
+};
+
 pub const OPPORTUNITY_PAGE_SIZE_CAP: usize = 100;
 
 #[derive(Debug)]

--- a/auction-server/src/opportunity/repository/mod.rs
+++ b/auction-server/src/opportunity/repository/mod.rs
@@ -27,7 +27,7 @@ mod remove_opportunities;
 mod remove_opportunity;
 
 pub use {
-    db::OpportunityTable,
+    db::*,
     models::*,
 };
 

--- a/auction-server/src/opportunity/repository/models.rs
+++ b/auction-server/src/opportunity/repository/models.rs
@@ -111,7 +111,6 @@ impl OpportunityMetadata for OpportunityMetadataSvm {
 
 // TODO Update metdata to exection_params
 #[derive(Clone, FromRow, Debug)]
-#[allow(dead_code)]
 pub struct Opportunity<T: OpportunityMetadata> {
     pub id:             Uuid,
     pub creation_time:  PrimitiveDateTime,

--- a/auction-server/src/opportunity/repository/refresh_in_memory_opportunity.rs
+++ b/auction-server/src/opportunity/repository/refresh_in_memory_opportunity.rs
@@ -1,13 +1,14 @@
 use {
     super::{
         InMemoryStore,
+        OpportunityTable,
         Repository,
     },
     crate::opportunity::entities::Opportunity,
     std::collections::hash_map::Entry,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn refresh_in_memory_opportunity(
         &self,
         opportunity: T::Opportunity,

--- a/auction-server/src/opportunity/repository/remove_opportunities.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunities.rs
@@ -12,7 +12,6 @@ use {
         },
         opportunity::entities,
     },
-    sqlx::Postgres,
 };
 
 impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {

--- a/auction-server/src/opportunity/repository/remove_opportunities.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunities.rs
@@ -13,10 +13,6 @@ use {
         opportunity::entities,
     },
     sqlx::Postgres,
-    time::{
-        OffsetDateTime,
-        PrimitiveDateTime,
-    },
 };
 
 impl<T: InMemoryStore> Repository<T> {
@@ -28,14 +24,7 @@ impl<T: InMemoryStore> Repository<T> {
         opportunity_key: &entities::OpportunityKey,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<Vec<T::Opportunity>> {
-        OpportunityTable::<T>::remove_opportunities(
-            db,
-            permission_key,
-            chain_id,
-            opportunity_key,
-            reason,
-        )
-        .await?;
+        OpportunityTable::<T>::remove_opportunities(db, permission_key, chain_id, reason).await?;
 
         let mut write_guard = self.in_memory_store.opportunities.write().await;
         let opportunities = write_guard.remove(opportunity_key);

--- a/auction-server/src/opportunity/repository/remove_opportunities.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunities.rs
@@ -15,16 +15,17 @@ use {
     sqlx::Postgres,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn remove_opportunities(
         &self,
-        db: &sqlx::Pool<Postgres>,
         permission_key: PermissionKey,
         chain_id: ChainId,
         opportunity_key: &entities::OpportunityKey,
         reason: OpportunityRemovalReason,
     ) -> anyhow::Result<Vec<T::Opportunity>> {
-        OpportunityTable::<T>::remove_opportunities(db, permission_key, chain_id, reason).await?;
+        self.db
+            .remove_opportunities(permission_key, chain_id, reason)
+            .await?;
 
         let mut write_guard = self.in_memory_store.opportunities.write().await;
         let opportunities = write_guard.remove(opportunity_key);

--- a/auction-server/src/opportunity/repository/remove_opportunity.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunity.rs
@@ -11,14 +11,15 @@ use {
     sqlx::Postgres,
 };
 
-impl<T: InMemoryStore> Repository<T> {
+impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {
     pub async fn remove_opportunity(
         &self,
-        db: &sqlx::Pool<Postgres>,
         opportunity: &T::Opportunity,
         reason: entities::OpportunityRemovalReason,
     ) -> anyhow::Result<()> {
-        OpportunityTable::<T>::remove_opportunity(db, opportunity, reason.into()).await?;
+        self.db
+            .remove_opportunity(opportunity, reason.into())
+            .await?;
 
         let key = opportunity.get_key();
         let mut write_guard = self.in_memory_store.opportunities.write().await;

--- a/auction-server/src/opportunity/repository/remove_opportunity.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunity.rs
@@ -1,7 +1,6 @@
 use {
     super::{
         db::OpportunityTable,
-        models::OpportunityRemovalReason,
         InMemoryStore,
         Repository,
     },
@@ -10,10 +9,6 @@ use {
         Opportunity,
     },
     sqlx::Postgres,
-    time::{
-        OffsetDateTime,
-        PrimitiveDateTime,
-    },
 };
 
 impl<T: InMemoryStore> Repository<T> {

--- a/auction-server/src/opportunity/repository/remove_opportunity.rs
+++ b/auction-server/src/opportunity/repository/remove_opportunity.rs
@@ -8,7 +8,6 @@ use {
         self,
         Opportunity,
     },
-    sqlx::Postgres,
 };
 
 impl<T: InMemoryStore, U: OpportunityTable<T>> Repository<T, U> {

--- a/auction-server/src/opportunity/service/add_opportunity.rs
+++ b/auction-server/src/opportunity/service/add_opportunity.rs
@@ -122,7 +122,6 @@ where
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
         crate::{
             api::ws,
             kernel::{

--- a/auction-server/src/opportunity/service/add_opportunity.rs
+++ b/auction-server/src/opportunity/service/add_opportunity.rs
@@ -283,6 +283,14 @@ mod tests {
         );
 
         let opportunities = service.repo.get_in_memory_opportunities().await;
+        let opportunities_by_key = service
+            .repo
+            .get_in_memory_opportunities_by_key(&OpportunityKey(
+                chain_id.clone(),
+                permission_key.clone(),
+            ))
+            .await;
+
         assert_eq!(opportunities.len(), 1);
         assert_eq!(
             opportunities
@@ -291,14 +299,6 @@ mod tests {
                 .len(),
             1
         );
-
-        let opportunities_by_key = service
-            .repo
-            .get_in_memory_opportunities_by_key(&OpportunityKey(
-                chain_id.clone(),
-                permission_key.clone(),
-            ))
-            .await;
         assert_eq!(opportunities_by_key.len(), 1);
         assert_eq!(
             opportunities_by_key[0],

--- a/auction-server/src/opportunity/service/add_opportunity.rs
+++ b/auction-server/src/opportunity/service/add_opportunity.rs
@@ -88,7 +88,7 @@ where
             self.repo.refresh_in_memory_opportunity(opp.clone()).await
         } else {
             self.repo
-                .add_opportunity(&self.db, opportunity_create.clone())
+                .add_opportunity(opportunity_create.clone())
                 .await?
         };
 

--- a/auction-server/src/opportunity/service/get_config.rs
+++ b/auction-server/src/opportunity/service/get_config.rs
@@ -6,10 +6,11 @@ use {
     crate::{
         api::RestError,
         kernel::entities::ChainId,
+        opportunity::repository::OpportunityTable,
     },
 };
 
-impl<T: ChainType> Service<T> {
+impl<T: ChainType, U: OpportunityTable<T::InMemoryStore>> Service<T, U> {
     pub fn get_config(&self, chain_id: &ChainId) -> Result<&T::Config, RestError> {
         self.config
             .get(chain_id)

--- a/auction-server/src/opportunity/service/get_opportunities.rs
+++ b/auction-server/src/opportunity/service/get_opportunities.rs
@@ -73,7 +73,6 @@ impl<T: ChainType> Service<T> {
                 })?;
                 self.repo
                     .get_opportunities(
-                        &self.db,
                         chain_id,
                         query_params.permission_key.clone(),
                         query_params.from_time,

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -296,7 +296,7 @@ impl Service<ChainTypeSvm> {
         );
         if let Err(e) = self
             .repo
-            .remove_opportunity(&self.db, &opportunity, removal_reason)
+            .remove_opportunity(&opportunity, removal_reason)
             .await
         {
             tracing::error!("Failed to remove opportunity: {:?}", e);

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -273,3 +273,68 @@ impl<T: ChainType, U: OpportunityTable<T::InMemoryStore>> Service<T, U> {
         }
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        crate::{
+            api::ws::{
+                self,
+                UpdateEvent,
+            },
+            kernel::traced_sender_svm::tests::MockRpcClient,
+            opportunity::repository::MockOpportunityTable,
+            server::setup_metrics_recorder,
+        },
+        std::sync::atomic::AtomicUsize,
+        tokio::sync::broadcast::Receiver,
+    };
+
+
+    impl Service<ChainTypeSvm, MockOpportunityTable<InMemoryStoreSvm>> {
+        pub fn new_with_mocks_svm(
+            chain_id: ChainId,
+            db: MockOpportunityTable<InMemoryStoreSvm>,
+            rpc_client: MockRpcClient,
+        ) -> (Self, Receiver<UpdateEvent>) {
+            let config_svm = crate::opportunity::service::ConfigSvm {
+                auction_service:         RwLock::new(None),
+                rpc_client:              RpcClient::new_sender(
+                    rpc_client,
+                    RpcClientConfig::default(),
+                ),
+                accepted_token_programs: vec![],
+            };
+
+            let (broadcast_sender, broadcast_receiver) = tokio::sync::broadcast::channel(100);
+
+            let mut chains_svm = HashMap::new();
+            chains_svm.insert(chain_id.clone(), config_svm);
+
+            let store = Arc::new(Store {
+                db:               DB::connect_lazy("https://test").unwrap(),
+                chains_evm:       HashMap::new(),
+                chains_svm:       HashMap::new(),
+                ws:               ws::WsState {
+                    subscriber_counter: AtomicUsize::new(0),
+                    broadcast_sender,
+                    broadcast_receiver,
+                },
+                secret_key:       "test".to_string(),
+                access_tokens:    RwLock::new(HashMap::new()),
+                metrics_recorder: setup_metrics_recorder().unwrap(),
+            });
+
+            let ws_receiver = store.ws.broadcast_receiver.resubscribe();
+
+            let service = Service::<ChainTypeSvm, MockOpportunityTable<InMemoryStoreSvm>>::new(
+                store.clone(),
+                db,
+                chains_svm,
+            );
+
+            (service, ws_receiver)
+        }
+    }
+}

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -258,7 +258,6 @@ impl ChainType for ChainTypeSvm {
 // TODO maybe just create a service per chain_id?
 pub struct Service<T: ChainType> {
     store:  Arc<Store>,
-    db:     DB,
     // TODO maybe after adding state for opportunity we can remove the arc
     repo:   Arc<Repository<T::InMemoryStore>>,
     config: HashMap<ChainId, T::Config>,
@@ -268,8 +267,7 @@ impl<T: ChainType> Service<T> {
     pub fn new(store: Arc<Store>, db: DB, config: HashMap<ChainId, T::Config>) -> Self {
         Self {
             store,
-            db,
-            repo: Arc::new(Repository::<T::InMemoryStore>::new()),
+            repo: Arc::new(Repository::<T::InMemoryStore>::new(db)),
             config,
         }
     }

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -3,6 +3,7 @@ use {
         InMemoryStore,
         InMemoryStoreEvm,
         InMemoryStoreSvm,
+        OpportunityTable,
         Repository,
     },
     crate::{
@@ -256,18 +257,18 @@ impl ChainType for ChainTypeSvm {
 }
 
 // TODO maybe just create a service per chain_id?
-pub struct Service<T: ChainType> {
+pub struct Service<T: ChainType, U: OpportunityTable<T::InMemoryStore> = DB> {
     store:  Arc<Store>,
     // TODO maybe after adding state for opportunity we can remove the arc
-    repo:   Arc<Repository<T::InMemoryStore>>,
+    repo:   Arc<Repository<T::InMemoryStore, U>>,
     config: HashMap<ChainId, T::Config>,
 }
 
-impl<T: ChainType> Service<T> {
-    pub fn new(store: Arc<Store>, db: DB, config: HashMap<ChainId, T::Config>) -> Self {
+impl<T: ChainType, U: OpportunityTable<T::InMemoryStore>> Service<T, U> {
+    pub fn new(store: Arc<Store>, db: U, config: HashMap<ChainId, T::Config>) -> Self {
         Self {
             store,
-            repo: Arc::new(Repository::<T::InMemoryStore>::new(db)),
+            repo: Arc::new(Repository::new(db)),
             config,
         }
     }

--- a/auction-server/src/opportunity/service/remove_invalid_or_expired_opportunities.rs
+++ b/auction-server/src/opportunity/service/remove_invalid_or_expired_opportunities.rs
@@ -68,11 +68,7 @@ where
                         reason = ?reason,
                         "Removing Opportunity",
                     );
-                    match self
-                        .repo
-                        .remove_opportunity(&self.db, opportunity, reason)
-                        .await
-                    {
+                    match self.repo.remove_opportunity(opportunity, reason).await {
                         Ok(()) => {
                             // TODO Remove this later
                             // For now we don't want searchers to update any of their code on EVM chains.

--- a/auction-server/src/opportunity/service/remove_opportunities.rs
+++ b/auction-server/src/opportunity/service/remove_opportunities.rs
@@ -43,7 +43,6 @@ impl Service<ChainTypeSvm> {
         let opportunities = self
             .repo
             .remove_opportunities(
-                &self.db,
                 permission_key.clone(),
                 input.chain_id.clone(),
                 &entities::OpportunityKey(input.chain_id.clone(), permission_key),

--- a/auction-server/src/opportunity/service/verification.rs
+++ b/auction-server/src/opportunity/service/verification.rs
@@ -17,7 +17,11 @@ use {
         },
         opportunity::{
             entities,
-            repository::InMemoryStore,
+            repository::{
+                InMemoryStore,
+                OpportunityTable,
+            },
+            service::InMemoryStoreSvm,
             token_spoof,
         },
     },
@@ -275,7 +279,9 @@ impl Verification<ChainTypeEvm> for Service<ChainTypeEvm> {
     }
 }
 
-impl Verification<ChainTypeSvm> for Service<ChainTypeSvm> {
+impl<U: OpportunityTable<InMemoryStoreSvm>> Verification<ChainTypeSvm>
+    for Service<ChainTypeSvm, U>
+{
     async fn verify_opportunity(
         &self,
         input: VerifyOpportunityInput<entities::OpportunityCreateSvm>,


### PR DESCRIPTION
This pull requests setups a structure to test the SVM opportunity service and more broadly the auction server.

How to review this PR:
- check out `auction-server/src/opportunity/service/add_opportunity.rs` to see an example of the tests that can be written with this setup.

The opportunity service interacts with 3 external dependencies:
- the database
- the solana rpc client
- the auction service

The strategy for testing is replacing each of them with mocks whose return values we control using the crate `mockall`.  To enable mocking with mockall, I refactor the interface between the opportunity repo and the database into a trait, then I use automock to create MockOpportunityTable a mock struct that implements the trait.

Next I'd like to focus on writing tests for SVM, for both opportunity service and auction service, covering Limo and Swap.