### PR TITLE
Bump Ubuntu release

### DIFF
--- a/.github/workflows/pypi-express-relay-utils.yml
+++ b/.github/workflows/pypi-express-relay-utils.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish-python:
     name: Publish Python SDK Package to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
GitHub deprecating Ubuntu 20.04:
https://github.com/actions/runner-images/issues/11101