### PR TITLE
fix: Batch swap simulations

### DIFF
--- a/auction-server/src/auction/service/auction_manager.rs
+++ b/auction-server/src/auction/service/auction_manager.rs
@@ -409,9 +409,6 @@ impl AuctionManager<Svm> for Service<Svm> {
         let mut bids = auction.bids.clone();
         bids.sort_by(|a, b| b.amount.cmp(&a.amount));
         return Ok(self
-            .config
-            .chain_config
-            .simulator
             .optimize_bids(&bids)
             .await
             .map(|x| x.value)

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -229,7 +229,7 @@ impl ChainTrait for Svm {
 
 pub struct ServiceInner<T: ChainTrait> {
     opportunity_service: Arc<opportunity_service::Service<T::OpportunityServiceType>>,
-    config:              Config<T::ConfigType>,
+    pub config:          Config<T::ConfigType>,
     repo:                Arc<Repository<T>>,
     task_tracker:        TaskTracker,
     event_sender:        broadcast::Sender<UpdateEvent>,

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -80,6 +80,7 @@ pub mod get_permission_keys_for_auction;
 pub mod handle_auction;
 pub mod handle_auctions;
 pub mod handle_bid;
+pub mod optimize_bids;
 pub mod simulator;
 pub mod submit_quote;
 pub mod update_bid_status;
@@ -229,7 +230,7 @@ impl ChainTrait for Svm {
 
 pub struct ServiceInner<T: ChainTrait> {
     opportunity_service: Arc<opportunity_service::Service<T::OpportunityServiceType>>,
-    pub config:          Config<T::ConfigType>,
+    config:              Config<T::ConfigType>,
     repo:                Arc<Repository<T>>,
     task_tracker:        TaskTracker,
     event_sender:        broadcast::Sender<UpdateEvent>,

--- a/auction-server/src/auction/service/optimize_bids.rs
+++ b/auction-server/src/auction/service/optimize_bids.rs
@@ -1,0 +1,47 @@
+use {
+    super::Service,
+    crate::{
+        auction::entities::Bid,
+        kernel::entities::Svm,
+    },
+    solana_client::rpc_response::{
+        Response,
+        RpcResult,
+    },
+};
+
+impl Service<Svm> {
+    /// Given a list of bids, tries to find the optimal set of bids that can be submitted to the chain
+    /// considering the current state of the chain and the pending transactions.
+    /// Right now, for simplicity, the method assume the bids are sorted, and tries to submit them in order
+    /// and only return the ones that are successfully submitted.
+    pub async fn optimize_bids(&self, bids: &[Bid<Svm>]) -> RpcResult<Vec<Bid<Svm>>> {
+        let simulator = &self.config.chain_config.simulator;
+        let pending_txs = simulator.fetch_pending_and_remove_old_txs().await;
+        let txs_to_fetch = pending_txs
+            .iter()
+            .chain(bids.iter().map(|bid| &bid.chain_data.transaction))
+            .cloned()
+            .collect::<Vec<_>>();
+        let accounts_config_with_context =
+            simulator.fetch_tx_accounts_via_rpc(&txs_to_fetch).await?;
+        let mut svm = simulator.setup_lite_svm(&accounts_config_with_context);
+
+        pending_txs.into_iter().for_each(|tx| {
+            let _ = svm.send_transaction(tx);
+        });
+        let mut res = vec![];
+        for bid in bids {
+            if svm
+                .send_transaction(bid.chain_data.transaction.clone())
+                .is_ok()
+            {
+                res.push(bid.clone());
+            }
+        }
+        Ok(Response {
+            value:   res,
+            context: accounts_config_with_context.context,
+        })
+    }
+}

--- a/auction-server/src/auction/service/optimize_bids.rs
+++ b/auction-server/src/auction/service/optimize_bids.rs
@@ -15,6 +15,7 @@ impl Service<Svm> {
     /// considering the current state of the chain and the pending transactions.
     /// Right now, for simplicity, the method assume the bids are sorted, and tries to submit them in order
     /// and only return the ones that are successfully submitted.
+    #[tracing::instrument(skip_all)]
     pub async fn optimize_bids(&self, bids_sorted: &[Bid<Svm>]) -> RpcResult<Vec<Bid<Svm>>> {
         let simulator = &self.config.chain_config.simulator;
         let pending_txs = simulator.fetch_pending_and_remove_old_txs().await;

--- a/auction-server/src/auction/service/simulator.rs
+++ b/auction-server/src/auction/service/simulator.rs
@@ -1,8 +1,4 @@
 use {
-    crate::{
-        auction::entities::Bid,
-        kernel::entities::Svm,
-    },
     futures::future::join_all,
     litesvm::{
         types::{
@@ -55,7 +51,7 @@ pub struct Simulator {
     account_cache: RwLock<HashMap<Pubkey, (Account, Instant)>>,
 }
 
-struct AccountsConfig {
+pub struct AccountsConfig {
     accounts:            HashMap<Pubkey, Account>,
     programs:            HashMap<Pubkey, Account>,
     upgradable_programs: HashMap<Pubkey, Account>,
@@ -257,7 +253,7 @@ impl Simulator {
     /// Uses the account cache to avoid fetching programs and lookup tables multiple times
     /// Returns an AccountsConfig struct that can be used to initialize the LiteSVM instance
     #[tracing::instrument(skip_all, fields(slot))]
-    async fn fetch_tx_accounts_via_rpc(
+    pub async fn fetch_tx_accounts_via_rpc(
         &self,
         transactions: &[VersionedTransaction],
     ) -> RpcResult<AccountsConfig> {
@@ -324,7 +320,10 @@ impl Simulator {
     }
 
     #[tracing::instrument(skip_all)]
-    fn setup_lite_svm(&self, accounts_config_with_context: &Response<AccountsConfig>) -> LiteSVM {
+    pub fn setup_lite_svm(
+        &self,
+        accounts_config_with_context: &Response<AccountsConfig>,
+    ) -> LiteSVM {
         let mut svm = LiteSVM::new()
             .with_sigverify(false)
             .with_blockhash_check(false)
@@ -398,39 +397,6 @@ impl Simulator {
         });
         let res = svm.simulate_transaction(transaction.clone());
         let res = Self::check_rent_exemption(&svm, res);
-        Ok(Response {
-            value:   res,
-            context: accounts_config_with_context.context,
-        })
-    }
-
-    /// Given a list of bids, tries to find the optimal set of bids that can be submitted to the chain
-    /// considering the current state of the chain and the pending transactions.
-    /// Right now, for simplicity, the method assume the bids are sorted, and tries to submit them in order
-    /// and only return the ones that are successfully submitted.
-    #[tracing::instrument(skip_all)]
-    pub async fn optimize_bids(&self, bids: &[Bid<Svm>]) -> RpcResult<Vec<Bid<Svm>>> {
-        let pending_txs = self.fetch_pending_and_remove_old_txs().await;
-        let txs_to_fetch = pending_txs
-            .iter()
-            .chain(bids.iter().map(|bid| &bid.chain_data.transaction))
-            .cloned()
-            .collect::<Vec<_>>();
-        let accounts_config_with_context = self.fetch_tx_accounts_via_rpc(&txs_to_fetch).await?;
-        let mut svm = self.setup_lite_svm(&accounts_config_with_context);
-
-        pending_txs.into_iter().for_each(|tx| {
-            let _ = svm.send_transaction(tx);
-        });
-        let mut res = vec![];
-        for bid in bids {
-            if svm
-                .send_transaction(bid.chain_data.transaction.clone())
-                .is_ok()
-            {
-                res.push(bid.clone());
-            }
-        }
         Ok(Response {
             value:   res,
             context: accounts_config_with_context.context,

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1374,10 +1374,10 @@ impl Verification<Svm> for Service<Svm> {
             }
         };
         let bid_chain_data = entities::BidChainDataSvm {
-            permission_account: bid_data.permission_account,
-            router: bid_data.router,
-            bid_payment_instruction_type,
-            transaction: transaction.clone(),
+            permission_account:           bid_data.permission_account,
+            router:                       bid_data.router,
+            bid_payment_instruction_type: bid_payment_instruction_type.clone(),
+            transaction:                  transaction.clone(),
         };
         let permission_key = bid_chain_data.get_permission_key();
         tracing::Span::current().record("permission_key", bid_data.permission_account.to_string());
@@ -1385,7 +1385,10 @@ impl Verification<Svm> for Service<Svm> {
             .await?;
         self.verify_signatures(&bid, &bid_chain_data, &bid_data.submit_type)
             .await?;
-        self.simulate_bid(&bid).await?;
+        // we handle simulating swap bids separately, in the get_quote function
+        if bid_payment_instruction_type == BidPaymentInstructionType::SubmitBid {
+            self.simulate_bid(&bid).await?;
+        }
 
         // Check if the bid is not duplicate
         let pending_bids = self

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -405,9 +405,6 @@ impl Service<ChainTypeSvm> {
         // here optimize_bids is used to batch the bid simulation
         if !bids.is_empty() {
             bids_filtered = auction_service
-                .config
-                .chain_config
-                .simulator
                 .optimize_bids(&bids)
                 .await
                 .map(|x| x.value)

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -402,7 +402,8 @@ impl Service<ChainTypeSvm> {
             }
         }
         let mut bids_filtered: Vec<Bid<Svm>> = Vec::new();
-        // here optimize_bids is used to batch the bid simulation
+        // here optimize_bids is used to batch the bid simulation.
+        // the first bid in the returned vector is the best bid that passes simulation.
         if !bids.is_empty() {
             bids_filtered = auction_service
                 .optimize_bids(&bids)

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -9,6 +9,7 @@ use {
         auction::{
             entities::{
                 Auction,
+                Bid,
                 BidPaymentInstructionType,
                 BidStatus,
                 BidStatusAuction,
@@ -22,7 +23,10 @@ use {
                 Service as AuctionService,
             },
         },
-        kernel::entities::PermissionKeySvm,
+        kernel::entities::{
+            PermissionKeySvm,
+            Svm,
+        },
         opportunity::{
             entities::{
                 self,
@@ -386,15 +390,6 @@ impl Service<ChainTypeSvm> {
         ];
         metrics::counter!("get_quote_total_bids", &labels).increment(1);
 
-        if bids.is_empty() {
-            tracing::warn!(opportunity = ?opportunity, "No bids found for quote opportunity");
-
-            // Remove opportunity to prevent further bids
-            // The handle auction loop will take care of the bids that were submitted late
-            self.remove_quote_opportunity(opportunity.clone()).await;
-            return Err(RestError::QuoteNotFound);
-        }
-
         // Find winner bid:
         match input.quote_create.tokens {
             entities::QuoteTokens::UserTokenSpecified { .. } => {
@@ -406,7 +401,32 @@ impl Service<ChainTypeSvm> {
                 bids.sort_by(|a, b| a.amount.cmp(&b.amount));
             }
         }
-        let winner_bid = bids.first().expect("failed to get first bid");
+        let mut bids_filtered: Vec<Bid<Svm>> = Vec::new();
+        // here optimize_bids is used to batch the bid simulation
+        if !bids.is_empty() {
+            bids_filtered = auction_service
+                .config
+                .chain_config
+                .simulator
+                .optimize_bids(&bids)
+                .await
+                .map(|x| x.value)
+                .map_err(|e| {
+                    tracing::error!("Failed to simulate swap bids: {:?}", e);
+                    RestError::TemporarilyUnavailable
+                })?;
+        }
+
+        if bids_filtered.is_empty() {
+            tracing::warn!(opportunity = ?opportunity, "No bids found for quote opportunity");
+
+            // Remove opportunity to prevent further bids
+            // The handle auction loop will take care of the bids that were submitted late
+            self.remove_quote_opportunity(opportunity.clone()).await;
+            return Err(RestError::QuoteNotFound);
+        }
+
+        let winner_bid = bids_filtered.first().expect("failed to get first bid");
 
         let swap_instruction = auction_service
             .extract_express_relay_instruction(


### PR DESCRIPTION
This PR enables batching the simulation of swap bids in `get_quote`, removing simulation from `handle_bid` for swap bids.