### PR TITLE
Feat/test verify bid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "gas-oracle",
  "litesvm",
  "mockall",
+ "mockall_double",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -4262,6 +4263,18 @@ name = "mockall_derive"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "mockall_double"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "express-relay-api-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -56,6 +56,7 @@ express-relay-api-types = { path = "api-types" }
 strum.workspace = true
 spl-associated-token-account = { workspace = true }
 spl-token = { workspace = true }
+mockall_double = "0.3.1"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/auction-server/api-types/Cargo.toml
+++ b/auction-server/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "express-relay-api-types"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Pyth Express Relay api types"
 repository = "https://github.com/pyth-network/per"

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -87,7 +87,7 @@ async fn root() -> String {
 pub mod profile;
 pub(crate) mod ws;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RestError {
     /// The request contained invalid parameters.
     BadParameters(String),
@@ -115,6 +115,8 @@ pub enum RestError {
     QuoteNotFound,
     /// Duplicate opportunity.
     DuplicateOpportunity,
+    /// Swao opportunity is not found.
+    SwapOpportunityNotFound,
 }
 
 impl RestError {
@@ -164,6 +166,10 @@ impl RestError {
             RestError::DuplicateOpportunity => (
                 StatusCode::BAD_REQUEST,
                 "Same opportunity is submitted recently".to_string(),
+            ),
+            RestError::SwapOpportunityNotFound => (
+                StatusCode::BAD_REQUEST,
+                "No swap opportunity with the given id found".to_string(),
             ),
         }
     }

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -115,7 +115,7 @@ pub enum RestError {
     QuoteNotFound,
     /// Duplicate opportunity.
     DuplicateOpportunity,
-    /// Swao opportunity is not found.
+    /// Swap opportunity is not found.
     SwapOpportunityNotFound,
 }
 

--- a/auction-server/src/auction/repository/add_auction.rs
+++ b/auction-server/src/auction/repository/add_auction.rs
@@ -1,16 +1,8 @@
 use {
     super::Repository,
     crate::auction::{
-        entities::{
-            self,
-            BidStatus,
-        },
+        entities,
         service::ChainTrait,
-    },
-    time::PrimitiveDateTime,
-    tracing::{
-        info_span,
-        Instrument,
     },
 };
 
@@ -31,19 +23,7 @@ impl<T: ChainTrait> Repository<T> {
         auction: entities::Auction<T>,
     ) -> anyhow::Result<entities::Auction<T>> {
         tracing::Span::current().record("auction_id", auction.id.to_string());
-        sqlx::query!(
-            "INSERT INTO auction (id, creation_time, permission_key, chain_id, chain_type, bid_collection_time, tx_hash) VALUES ($1, $2, $3, $4, $5, $6, $7)",
-            auction.id,
-            PrimitiveDateTime::new(auction.creation_time.date(), auction.creation_time.time()),
-            T::convert_permission_key(&auction.permission_key),
-            auction.chain_id,
-            T::get_chain_type() as _,
-            PrimitiveDateTime::new(auction.bid_collection_time.date(), auction.bid_collection_time.time()),
-            auction.tx_hash.clone().map(|tx_hash| T::BidStatusType::convert_tx_hash(&tx_hash)),
-        )
-        .execute(&self.db)
-            .instrument(info_span!("db_add_auction"))
-        .await?;
+        self.db.add_auction(&auction).await?;
 
         self.remove_in_memory_pending_bids(auction.bids.as_slice())
             .await;

--- a/auction-server/src/auction/repository/conclude_auction.rs
+++ b/auction-server/src/auction/repository/conclude_auction.rs
@@ -6,29 +6,13 @@ use {
         },
         service::ChainTrait,
     },
-    time::{
-        OffsetDateTime,
-        PrimitiveDateTime,
-    },
-    tracing::{
-        info_span,
-        Instrument,
-    },
 };
 
 impl<T: ChainTrait> Repository<T> {
     #[tracing::instrument(skip_all, name = "conclude_auction_repo", fields(auction_id))]
     pub async fn conclude_auction(&self, auction_id: entities::AuctionId) -> anyhow::Result<()> {
         tracing::Span::current().record("auction_id", auction_id.to_string());
-        let now = OffsetDateTime::now_utc();
-        sqlx::query!(
-            "UPDATE auction SET conclusion_time = $1 WHERE id = $2 AND conclusion_time IS NULL",
-            PrimitiveDateTime::new(now.date(), now.time()),
-            auction_id,
-        )
-        .execute(&self.db)
-        .instrument(info_span!("db_conclude_auction"))
-        .await?;
+        self.db.conclude_auction(auction_id).await?;
         self.remove_in_memory_auction(auction_id).await;
         Ok(())
     }

--- a/auction-server/src/auction/repository/get_bid.rs
+++ b/auction-server/src/auction/repository/get_bid.rs
@@ -1,10 +1,5 @@
 use {
-    super::{
-        models::{
-            self,
-        },
-        Repository,
-    },
+    super::Repository,
     crate::{
         api::RestError,
         auction::{
@@ -12,46 +7,13 @@ use {
             service::ChainTrait,
         },
     },
-    tracing::{
-        info_span,
-        Instrument,
-    },
 };
 
 impl<T: ChainTrait> Repository<T> {
     pub async fn get_bid(&self, bid_id: entities::BidId) -> Result<entities::Bid<T>, RestError> {
-        let bid: models::Bid<T> =
-            sqlx::query_as("SELECT * FROM bid WHERE id = $1 AND chain_id = $2")
-                .bind(bid_id)
-                .bind(self.chain_id.clone())
-                .fetch_one(&self.db)
-                .instrument(info_span!("db_get_bid"))
-                .await
-                .map_err(|e| match e {
-                    sqlx::Error::RowNotFound => RestError::BidNotFound,
-                    _ => {
-                        tracing::error!(
-                            error = e.to_string(),
-                            bid_id = bid_id.to_string(),
-                            "Failed to get bid from db"
-                        );
-                        RestError::TemporarilyUnavailable
-                    }
-                })?;
-
-        let auction: Option<models::Auction> = match bid.auction_id {
-            Some(auction_id) => {
-                let auction: models::Auction = sqlx::query_as("SELECT * FROM auction WHERE id = $1")
-                    .bind(auction_id)
-                    .fetch_one(&self.db)
-                    .instrument(info_span!("db_get_bid_auction"))
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = e.to_string(), bid = ?bid, auction_id = auction_id.to_string(), "Failed to get auction for bid from db");
-                        RestError::TemporarilyUnavailable
-                    })?;
-                Some(auction)
-            }
+        let bid = self.db.get_bid(bid_id, self.chain_id.clone()).await?;
+        let auction = match bid.auction_id {
+            Some(auction_id) => Some(self.db.get_auction(auction_id).await?),
             None => None,
         };
 

--- a/auction-server/src/auction/repository/get_bids.rs
+++ b/auction-server/src/auction/repository/get_bids.rs
@@ -1,78 +1,27 @@
 use {
     super::{
-        models,
-        Bid,
         ChainTrait,
         Repository,
     },
     crate::{
         api::RestError,
         auction::entities,
-        kernel::entities::ChainId,
         models::ProfileId,
     },
-    sqlx::QueryBuilder,
     time::OffsetDateTime,
-    tracing::{
-        info_span,
-        Instrument,
-    },
 };
 
 impl<T: ChainTrait> Repository<T> {
-    async fn get_auctions_by_bids_model(
-        &self,
-        bids: &[models::Bid<T>],
-    ) -> Result<Vec<models::Auction>, RestError> {
-        let auction_ids: Vec<entities::AuctionId> =
-            bids.iter().filter_map(|bid| bid.auction_id).collect();
-        sqlx::query_as("SELECT * FROM auction WHERE id = ANY($1)")
-            .bind(auction_ids)
-            .fetch_all(&self.db)
-            .instrument(info_span!("db_get_auctions_by_bids"))
-            .await
-            .map_err(|e| {
-                tracing::error!("DB: Failed to fetch auctions: {}", e);
-                RestError::TemporarilyUnavailable
-            })
-    }
-
-    async fn get_bids_model(
-        &self,
-        chain_id: ChainId,
-        profile_id: ProfileId,
-        from_time: Option<OffsetDateTime>,
-    ) -> Result<Vec<Bid<T>>, RestError> {
-        let mut query = QueryBuilder::new("SELECT * from bid where profile_id = ");
-        query
-            .push_bind(profile_id)
-            .push(" AND chain_id = ")
-            .push_bind(chain_id);
-        if let Some(from_time) = from_time {
-            query.push(" AND initiation_time >= ");
-            query.push_bind(from_time);
-        }
-        query.push(" ORDER BY initiation_time ASC LIMIT 20");
-        query
-            .build_query_as()
-            .fetch_all(&self.db)
-            .instrument(info_span!("db_get_bids"))
-            .await
-            .map_err(|e| {
-                tracing::error!("DB: Failed to fetch bids: {}", e);
-                RestError::TemporarilyUnavailable
-            })
-    }
-
     pub async fn get_bids(
         &self,
         profile_id: ProfileId,
         from_time: Option<OffsetDateTime>,
     ) -> Result<Vec<entities::Bid<T>>, RestError> {
         let bids = self
-            .get_bids_model(self.chain_id.clone(), profile_id, from_time)
+            .db
+            .get_bids(self.chain_id.clone(), profile_id, from_time)
             .await?;
-        let auctions = self.get_auctions_by_bids_model(&bids).await?;
+        let auctions = self.db.get_auctions_by_bids(&bids).await?;
 
         Ok(bids
             .into_iter()

--- a/auction-server/src/auction/repository/mod.rs
+++ b/auction-server/src/auction/repository/mod.rs
@@ -3,10 +3,7 @@ use {
         entities,
         service::ChainTrait,
     },
-    crate::kernel::{
-        db::DB,
-        entities::ChainId,
-    },
+    crate::kernel::entities::ChainId,
     axum_prometheus::metrics,
     solana_sdk::pubkey::Pubkey,
     std::collections::{
@@ -90,15 +87,15 @@ impl<T: ChainTrait> Default for InMemoryStore<T> {
 #[derive(Debug)]
 pub struct Repository<T: ChainTrait> {
     pub in_memory_store: InMemoryStore<T>,
-    pub db:              DB,
+    pub db:              Box<dyn models::DBTrait<T>>,
     pub chain_id:        ChainId,
 }
 
 impl<T: ChainTrait> Repository<T> {
-    pub fn new(db: DB, chain_id: ChainId) -> Self {
+    pub fn new(db: impl models::DBTrait<T>, chain_id: ChainId) -> Self {
         Self {
             in_memory_store: InMemoryStore::default(),
-            db,
+            db: Box::new(db),
             chain_id,
         }
     }

--- a/auction-server/src/auction/repository/mod.rs
+++ b/auction-server/src/auction/repository/mod.rs
@@ -87,12 +87,12 @@ impl<T: ChainTrait> Default for InMemoryStore<T> {
 #[derive(Debug)]
 pub struct Repository<T: ChainTrait> {
     pub in_memory_store: InMemoryStore<T>,
-    pub db:              Box<dyn models::DBTrait<T>>,
+    pub db:              Box<dyn models::Database<T>>,
     pub chain_id:        ChainId,
 }
 
 impl<T: ChainTrait> Repository<T> {
-    pub fn new(db: impl models::DBTrait<T>, chain_id: ChainId) -> Self {
+    pub fn new(db: impl models::Database<T>, chain_id: ChainId) -> Self {
         Self {
             in_memory_store: InMemoryStore::default(),
             db: Box::new(db),

--- a/auction-server/src/auction/repository/models.rs
+++ b/auction-server/src/auction/repository/models.rs
@@ -1,17 +1,26 @@
+#[cfg(test)]
+use mockall::automock;
 use {
     super::entities::{
         self,
         BidChainData,
+        BidStatus as _,
     },
     crate::{
+        api::RestError,
         auction::service::ChainTrait,
-        kernel::entities::{
-            Evm,
-            PermissionKeySvm,
-            Svm,
+        kernel::{
+            db::DB,
+            entities::{
+                ChainId,
+                Evm,
+                PermissionKeySvm,
+                Svm,
+            },
         },
         models::ProfileId,
     },
+    axum::async_trait,
     ethers::types::{
         Address,
         Bytes,
@@ -37,6 +46,7 @@ use {
         },
         FromRow,
         Postgres,
+        QueryBuilder,
     },
     std::{
         fmt::Debug,
@@ -48,6 +58,10 @@ use {
         OffsetDateTime,
         PrimitiveDateTime,
         UtcOffset,
+    },
+    tracing::{
+        info_span,
+        Instrument,
     },
 };
 
@@ -597,5 +611,202 @@ impl<T: ChainTrait + ModelTrait<T>> Bid<T> {
             status:     T::get_bid_status_entity(self, auction)?,
             chain_data: T::get_chain_data_entity(self)?,
         })
+    }
+}
+
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait DBTrait<T: ChainTrait>: Debug + Send + Sync + 'static {
+    async fn add_auction(&self, auction: &entities::Auction<T>) -> anyhow::Result<()>;
+    async fn add_bid(&self, bid: &Bid<T>) -> Result<(), RestError>;
+    async fn conclude_auction(&self, auction_id: entities::AuctionId) -> anyhow::Result<()>;
+    async fn get_bid(
+        &self,
+        bid_id: entities::BidId,
+        chain_id: ChainId,
+    ) -> Result<Bid<T>, RestError>;
+    async fn get_auction(&self, auction_id: entities::AuctionId) -> Result<Auction, RestError>;
+    async fn get_auctions_by_bids(&self, bids: &[Bid<T>]) -> Result<Vec<Auction>, RestError>;
+    async fn get_bids(
+        &self,
+        chain_id: ChainId,
+        profile_id: ProfileId,
+        from_time: Option<OffsetDateTime>,
+    ) -> Result<Vec<Bid<T>>, RestError>;
+    async fn submit_auction(
+        &self,
+        auction: &entities::Auction<T>,
+        transaction_hash: &entities::TxHash<T>,
+    ) -> anyhow::Result<entities::Auction<T>>;
+    async fn update_bid_status(
+        &self,
+        bid: &entities::Bid<T>,
+        new_status: &T::BidStatusType,
+    ) -> anyhow::Result<bool>;
+}
+
+#[async_trait]
+impl<T: ChainTrait> DBTrait<T> for DB {
+    async fn add_auction(&self, auction: &entities::Auction<T>) -> anyhow::Result<()> {
+        sqlx::query!(
+            "INSERT INTO auction (id, creation_time, permission_key, chain_id, chain_type, bid_collection_time, tx_hash) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            auction.id,
+            PrimitiveDateTime::new(auction.creation_time.date(), auction.creation_time.time()),
+            T::convert_permission_key(&auction.permission_key),
+            auction.chain_id,
+            T::get_chain_type() as _,
+            PrimitiveDateTime::new(auction.bid_collection_time.date(), auction.bid_collection_time.time()),
+            auction.tx_hash.clone().map(|tx_hash| T::BidStatusType::convert_tx_hash(&tx_hash)),
+        )
+        .execute(self)
+            .instrument(info_span!("db_add_auction"))
+        .await?;
+        Ok(())
+    }
+
+    async fn add_bid(&self, bid: &Bid<T>) -> Result<(), RestError> {
+        sqlx::query!("INSERT INTO bid (id, creation_time, permission_key, chain_id, chain_type, bid_amount, status, initiation_time, profile_id, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+            bid.id,
+            bid.creation_time,
+            bid.permission_key,
+            bid.chain_id,
+            bid.chain_type as _,
+            bid.bid_amount,
+            bid.status as _,
+            bid.initiation_time,
+            bid.profile_id,
+            serde_json::to_value(bid.metadata.clone()).expect("Failed to serialize metadata"),
+        ).execute(self)
+            .instrument(info_span!("db_add_bid"))
+            .await.map_err(|e| {
+            tracing::error!(error = e.to_string(), bid = ?bid, "DB: Failed to insert bid");
+            RestError::TemporarilyUnavailable
+        })?;
+        Ok(())
+    }
+
+    async fn conclude_auction(&self, auction_id: entities::AuctionId) -> anyhow::Result<()> {
+        let now = OffsetDateTime::now_utc();
+        sqlx::query!(
+            "UPDATE auction SET conclusion_time = $1 WHERE id = $2 AND conclusion_time IS NULL",
+            PrimitiveDateTime::new(now.date(), now.time()),
+            auction_id,
+        )
+        .execute(self)
+        .instrument(info_span!("db_conclude_auction"))
+        .await?;
+        Ok(())
+    }
+
+    async fn get_bid(
+        &self,
+        bid_id: entities::BidId,
+        chain_id: ChainId,
+    ) -> Result<Bid<T>, RestError> {
+        sqlx::query_as("SELECT * FROM bid WHERE id = $1 AND chain_id = $2")
+            .bind(bid_id)
+            .bind(chain_id)
+            .fetch_one(self)
+            .instrument(info_span!("db_get_bid"))
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => RestError::BidNotFound,
+                _ => {
+                    tracing::error!(
+                        error = e.to_string(),
+                        bid_id = bid_id.to_string(),
+                        "Failed to get bid from db"
+                    );
+                    RestError::TemporarilyUnavailable
+                }
+            })
+    }
+
+    async fn get_auction(&self, auction_id: entities::AuctionId) -> Result<Auction, RestError> {
+        sqlx::query_as("SELECT * FROM auction WHERE id = $1")
+            .bind(auction_id)
+            .fetch_one(self)
+            .instrument(info_span!("db_get_auction"))
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    error = e.to_string(),
+                    auction_id = auction_id.to_string(),
+                    "Failed to get auction from db"
+                );
+                RestError::TemporarilyUnavailable
+            })
+    }
+
+    async fn get_auctions_by_bids(&self, bids: &[Bid<T>]) -> Result<Vec<Auction>, RestError> {
+        let auction_ids: Vec<entities::AuctionId> =
+            bids.iter().filter_map(|bid| bid.auction_id).collect();
+        sqlx::query_as("SELECT * FROM auction WHERE id = ANY($1)")
+            .bind(auction_ids)
+            .fetch_all(self)
+            .instrument(info_span!("db_get_auctions_by_bids"))
+            .await
+            .map_err(|e| {
+                tracing::error!("DB: Failed to fetch auctions: {}", e);
+                RestError::TemporarilyUnavailable
+            })
+    }
+
+    async fn get_bids(
+        &self,
+        chain_id: ChainId,
+        profile_id: ProfileId,
+        from_time: Option<OffsetDateTime>,
+    ) -> Result<Vec<Bid<T>>, RestError> {
+        let mut query = QueryBuilder::new("SELECT * from bid where profile_id = ");
+        query
+            .push_bind(profile_id)
+            .push(" AND chain_id = ")
+            .push_bind(chain_id);
+        if let Some(from_time) = from_time {
+            query.push(" AND initiation_time >= ");
+            query.push_bind(from_time);
+        }
+        query.push(" ORDER BY initiation_time ASC LIMIT 20");
+        query
+            .build_query_as()
+            .fetch_all(self)
+            .instrument(info_span!("db_get_bids"))
+            .await
+            .map_err(|e| {
+                tracing::error!("DB: Failed to fetch bids: {}", e);
+                RestError::TemporarilyUnavailable
+            })
+    }
+
+    async fn submit_auction(
+        &self,
+        auction: &entities::Auction<T>,
+        transaction_hash: &entities::TxHash<T>,
+    ) -> anyhow::Result<entities::Auction<T>> {
+        let mut auction = auction.clone();
+        let now = OffsetDateTime::now_utc();
+        auction.tx_hash = Some(transaction_hash.clone());
+        auction.submission_time = Some(now);
+        sqlx::query!("UPDATE auction SET submission_time = $1, tx_hash = $2 WHERE id = $3 AND submission_time IS NULL",
+            PrimitiveDateTime::new(now.date(), now.time()),
+            T::BidStatusType::convert_tx_hash(transaction_hash),
+            auction.id,
+        ).execute(self).instrument(info_span!("db_update_auction")).await?;
+        Ok(auction)
+    }
+
+    async fn update_bid_status(
+        &self,
+        bid: &entities::Bid<T>,
+        new_status: &T::BidStatusType,
+    ) -> anyhow::Result<bool> {
+        let update_query = T::get_update_bid_query(bid, new_status.clone())?;
+        let query_result = update_query
+            .execute(self)
+            .instrument(info_span!("db_update_bid_status"))
+            .await?;
+        Ok(query_result.rows_affected() > 0)
     }
 }

--- a/auction-server/src/auction/repository/models.rs
+++ b/auction-server/src/auction/repository/models.rs
@@ -617,7 +617,7 @@ impl<T: ChainTrait + ModelTrait<T>> Bid<T> {
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait DBTrait<T: ChainTrait>: Debug + Send + Sync + 'static {
+pub trait Database<T: ChainTrait>: Debug + Send + Sync + 'static {
     async fn add_auction(&self, auction: &entities::Auction<T>) -> anyhow::Result<()>;
     async fn add_bid(&self, bid: &Bid<T>) -> Result<(), RestError>;
     async fn conclude_auction(&self, auction_id: entities::AuctionId) -> anyhow::Result<()>;
@@ -647,7 +647,7 @@ pub trait DBTrait<T: ChainTrait>: Debug + Send + Sync + 'static {
 }
 
 #[async_trait]
-impl<T: ChainTrait> DBTrait<T> for DB {
+impl<T: ChainTrait> Database<T> for DB {
     async fn add_auction(&self, auction: &entities::Auction<T>) -> anyhow::Result<()> {
         sqlx::query!(
             "INSERT INTO auction (id, creation_time, permission_key, chain_id, chain_type, bid_collection_time, tx_hash) VALUES ($1, $2, $3, $4, $5, $6, $7)",

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -287,7 +287,10 @@ pub mod tests {
             SwapInstructionAccountPositions,
         },
         crate::{
-            auction::repository::Repository,
+            auction::repository::{
+                DBTrait,
+                Repository,
+            },
             kernel::{
                 db::DB,
                 entities::{
@@ -319,8 +322,9 @@ pub mod tests {
 
     impl Service<Svm> {
         pub fn new_with_mocks_svm(
-            opportunity_service: MockOpportunityService<ChainTypeSvm, DB>,
             chain_id: ChainId,
+            db: impl DBTrait<Svm>,
+            opportunity_service: MockOpportunityService<ChainTypeSvm, DB>,
             rpc_client: MockRpcClient,
             broadcaster_client: MockRpcClient,
         ) -> Self {
@@ -366,10 +370,7 @@ pub mod tests {
                         prioritization_fee_percentile: None,
                     },
                 },
-                repo:                Arc::new(Repository::new(
-                    DB::connect_lazy("https://test").unwrap(),
-                    chain_id.clone(),
-                )),
+                repo:                Arc::new(Repository::new(db, chain_id.clone())),
                 task_tracker:        TaskTracker::new(),
                 event_sender:        broadcast::channel(1).0,
             }))

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -231,7 +231,7 @@ impl ChainTrait for Svm {
 }
 
 pub struct ServiceInner<T: ChainTrait> {
-    opportunity_service: Arc<OpportunityService<T::OpportunityServiceType, DB>>,
+    opportunity_service: Arc<OpportunityService<T::OpportunityServiceType>>,
     config:              Config<T::ConfigType>,
     repo:                Arc<Repository<T>>,
     task_tracker:        TaskTracker,
@@ -251,7 +251,7 @@ impl<T: ChainTrait> Service<T> {
     pub fn new(
         db: DB,
         config: Config<T::ConfigType>,
-        opportunity_service: Arc<OpportunityService<T::OpportunityServiceType, DB>>,
+        opportunity_service: Arc<OpportunityService<T::OpportunityServiceType>>,
         task_tracker: TaskTracker,
         event_sender: broadcast::Sender<UpdateEvent>,
     ) -> Self {
@@ -291,7 +291,6 @@ pub mod tests {
                 Repository,
             },
             kernel::{
-                db::DB,
                 entities::{
                     ChainId,
                     Svm,
@@ -323,7 +322,7 @@ pub mod tests {
         pub fn new_with_mocks_svm(
             chain_id: ChainId,
             db: impl Database<Svm>,
-            opportunity_service: MockOpportunityService<ChainTypeSvm, DB>,
+            opportunity_service: MockOpportunityService<ChainTypeSvm>,
             rpc_client: MockRpcClient,
             broadcaster_client: MockRpcClient,
         ) -> Self {

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+use crate::opportunity::service::MockService as OpportunityService;
+#[cfg(not(test))]
+use crate::opportunity::service::Service as OpportunityService;
 use {
     super::{
         entities,
@@ -228,7 +232,7 @@ impl ChainTrait for Svm {
 }
 
 pub struct ServiceInner<T: ChainTrait> {
-    opportunity_service: Arc<opportunity_service::Service<T::OpportunityServiceType>>,
+    opportunity_service: Arc<OpportunityService<T::OpportunityServiceType, DB>>,
     config:              Config<T::ConfigType>,
     repo:                Arc<Repository<T>>,
     task_tracker:        TaskTracker,
@@ -248,7 +252,7 @@ impl<T: ChainTrait> Service<T> {
     pub fn new(
         db: DB,
         config: Config<T::ConfigType>,
-        opportunity_service: Arc<opportunity_service::Service<T::OpportunityServiceType>>,
+        opportunity_service: Arc<OpportunityService<T::OpportunityServiceType, DB>>,
         task_tracker: TaskTracker,
         event_sender: broadcast::Sender<UpdateEvent>,
     ) -> Self {
@@ -266,4 +270,109 @@ impl<T: ChainTrait> Service<T> {
 pub enum ServiceEnum {
     Evm(Service<Evm>),
     Svm(Service<Svm>),
+}
+
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::{
+            simulator::Simulator,
+            Config,
+            ConfigSvm,
+            ExpressRelaySvm,
+            Service,
+            ServiceInner,
+            SubmitBidInstructionAccountPositions,
+            SwapInstructionAccountPositions,
+        },
+        crate::{
+            auction::repository::Repository,
+            kernel::{
+                db::DB,
+                entities::{
+                    ChainId,
+                    Svm,
+                },
+                traced_sender_svm::{
+                    tests::MockRpcClient,
+                    TracedSenderSvm,
+                },
+            },
+            opportunity::service::{
+                ChainTypeSvm,
+                MockService as MockOpportunityService,
+            },
+        },
+        solana_client::{
+            nonblocking::rpc_client::RpcClient,
+            rpc_client::RpcClientConfig,
+        },
+        solana_sdk::{
+            pubkey::Pubkey,
+            signature::Keypair,
+        },
+        std::sync::Arc,
+        tokio::sync::broadcast,
+        tokio_util::task::TaskTracker,
+    };
+
+    impl Service<Svm> {
+        pub fn new_with_mocks_svm(
+            opportunity_service: MockOpportunityService<ChainTypeSvm, DB>,
+            chain_id: ChainId,
+            rpc_client: MockRpcClient,
+            broadcaster_client: MockRpcClient,
+        ) -> Self {
+            Service::<Svm>(Arc::new(ServiceInner::<Svm> {
+                opportunity_service: Arc::new(opportunity_service),
+                config:              Config {
+                    chain_id:     chain_id.clone(),
+                    chain_config: ConfigSvm {
+                        client:                        RpcClient::new_sender(
+                            rpc_client,
+                            RpcClientConfig::default(),
+                        ),
+                        express_relay:                 ExpressRelaySvm {
+                            program_id:                               Pubkey::new_unique(),
+                            relayer:                                  Keypair::new(),
+                            submit_bid_instruction_account_positions:
+                                SubmitBidInstructionAccountPositions {
+                                    permission_account: 0,
+                                    router_account:     1,
+                                },
+                            swap_instruction_account_positions:
+                                SwapInstructionAccountPositions {
+                                    router_token_account:   0,
+                                    user_wallet_account:    1,
+                                    mint_searcher_account:  2,
+                                    mint_user_account:      3,
+                                    token_program_searcher: 4,
+                                    token_program_user:     5,
+                                },
+                        },
+                        simulator:                     Simulator::new(TracedSenderSvm::new_client(
+                            chain_id.clone(),
+                            "https://test",
+                            2,
+                            RpcClientConfig::default(),
+                        )),
+                        ws_address:                    "ws://test".to_string(),
+                        tx_broadcaster_clients:        vec![RpcClient::new_sender(
+                            broadcaster_client,
+                            RpcClientConfig::default(),
+                        )],
+                        log_sender:                    broadcast::channel(1).0,
+                        prioritization_fee_percentile: None,
+                    },
+                },
+                repo:                Arc::new(Repository::new(
+                    DB::connect_lazy("https://test").unwrap(),
+                    chain_id.clone(),
+                )),
+                task_tracker:        TaskTracker::new(),
+                event_sender:        broadcast::channel(1).0,
+            }))
+        }
+    }
 }

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -1,6 +1,4 @@
-#[cfg(test)]
-use crate::opportunity::service::tests::MockService as OpportunityService;
-#[cfg(not(test))]
+#[double]
 use crate::opportunity::service::Service as OpportunityService;
 use {
     super::{
@@ -48,6 +46,7 @@ use {
         },
     },
     gas_oracle::EthProviderOracle,
+    mockall_double::double,
     solana_client::{
         nonblocking::rpc_client::RpcClient,
         rpc_response::{
@@ -288,7 +287,7 @@ pub mod tests {
         },
         crate::{
             auction::repository::{
-                DBTrait,
+                Database,
                 Repository,
             },
             kernel::{
@@ -303,8 +302,8 @@ pub mod tests {
                 },
             },
             opportunity::service::{
-                tests::MockService as MockOpportunityService,
                 ChainTypeSvm,
+                MockService as MockOpportunityService,
             },
         },
         solana_client::{
@@ -323,7 +322,7 @@ pub mod tests {
     impl Service<Svm> {
         pub fn new_with_mocks_svm(
             chain_id: ChainId,
-            db: impl DBTrait<Svm>,
+            db: impl Database<Svm>,
             opportunity_service: MockOpportunityService<ChainTypeSvm, DB>,
             rpc_client: MockRpcClient,
             broadcaster_client: MockRpcClient,

--- a/auction-server/src/auction/service/mod.rs
+++ b/auction-server/src/auction/service/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::opportunity::service::MockService as OpportunityService;
+use crate::opportunity::service::tests::MockService as OpportunityService;
 #[cfg(not(test))]
 use crate::opportunity::service::Service as OpportunityService;
 use {
@@ -300,8 +300,8 @@ pub mod tests {
                 },
             },
             opportunity::service::{
+                tests::MockService as MockOpportunityService,
                 ChainTypeSvm,
-                MockService as MockOpportunityService,
             },
         },
         solana_client::{

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1443,7 +1443,6 @@ mod tests {
                 service::verification::Verification,
             },
             kernel::{
-                db::DB,
                 entities::Svm,
                 traced_sender_svm::tests::MockRpcClient,
             },
@@ -1472,7 +1471,7 @@ mod tests {
         let user = Pubkey::new_unique();
         let transaction = system_transaction::transfer(&searcher, &user, 10, Hash::default());
 
-        let mut opportunity_service = MockService::<ChainTypeSvm, DB>::default();
+        let mut opportunity_service = MockService::<ChainTypeSvm>::default();
         opportunity_service
             .expect_get_live_opportunities()
             .returning(|_| vec![]);

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1439,7 +1439,7 @@ mod tests {
                     BidChainDataSwapCreateSvm,
                     BidCreate,
                 },
-                repository::MockDBTrait,
+                repository::MockDatabase,
                 service::verification::Verification,
             },
             kernel::{
@@ -1448,8 +1448,8 @@ mod tests {
                 traced_sender_svm::tests::MockRpcClient,
             },
             opportunity::service::{
-                tests::MockService,
                 ChainTypeSvm,
+                MockService,
             },
         },
         solana_sdk::{
@@ -1480,7 +1480,7 @@ mod tests {
             .expect_get_live_opportunity_by_id()
             .returning(|_| None);
 
-        let db = MockDBTrait::<Svm>::default();
+        let db = MockDatabase::<Svm>::default();
         let service = super::Service::new_with_mocks_svm(
             chain_id.clone(),
             db,

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1448,8 +1448,8 @@ mod tests {
                 traced_sender_svm::tests::MockRpcClient,
             },
             opportunity::service::{
+                tests::MockService,
                 ChainTypeSvm,
-                MockService,
             },
         },
         solana_sdk::{

--- a/auction-server/src/main.rs
+++ b/auction-server/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(dead_code))]
+
 use {
     crate::server::run_migrations,
     anyhow::Result,

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -304,7 +304,6 @@ pub mod tests {
         tokio::sync::broadcast::Receiver,
     };
 
-
     impl Service<ChainTypeSvm> {
         pub fn new_with_mocks_svm(
             chain_id: ChainId,
@@ -347,43 +346,44 @@ pub mod tests {
             (service, ws_receiver)
         }
     }
+}
 
-    mock! {
-        pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
-            pub fn new(
-                store: Arc<Store>,
-                task_tracker: TaskTracker,
-                db: U,
-                config: HashMap<ChainId, T::Config>,
-            ) -> Self;
-            pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
-            pub async fn get_live_opportunities(&self, input: get_live_opportunities::GetLiveOpportunitiesInput) -> Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>;
-            pub async fn get_live_opportunity_by_id(&self, input: get_opportunities::GetLiveOpportunityByIdInput) -> Option<<T::InMemoryStore as InMemoryStore>::Opportunity>;
-            pub async fn remove_invalid_or_expired_opportunities(&self);
-            pub async fn update_metrics(&self);
-            pub async fn remove_opportunities(
-                &self,
-                input: remove_opportunities::RemoveOpportunitiesInput,
-            ) -> Result<(), crate::api::RestError>;
-            pub async fn add_opportunity(
-                &self,
-                input: add_opportunity::AddOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
-            ) -> Result<<T::InMemoryStore as InMemoryStore>::Opportunity, crate::api::RestError>;
-            pub async fn get_opportunities(
-                &self,
-                input: get_opportunities::GetOpportunitiesInput,
-            ) -> Result<Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>, crate::api::RestError>;
-            pub async fn get_quote(&self, input: get_quote::GetQuoteInput) -> Result<crate::opportunity::entities::Quote, crate::api::RestError>;
-            pub async fn handle_opportunity_bid(
-                &self,
-                input: handle_opportunity_bid::HandleOpportunityBidInput,
-            ) -> Result<uuid::Uuid, crate::api::RestError>;
-        }
-        impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
-            async fn verify_opportunity(
-                &self,
-                input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
-            ) -> Result<crate::opportunity::entities::OpportunityVerificationResult, crate::api::RestError>;
-        }
+#[cfg(test)]
+mock! {
+    pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
+        pub fn new(
+            store: Arc<Store>,
+            task_tracker: TaskTracker,
+            db: U,
+            config: HashMap<ChainId, T::Config>,
+        ) -> Self;
+        pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
+        pub async fn get_live_opportunities(&self, input: get_live_opportunities::GetLiveOpportunitiesInput) -> Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+        pub async fn get_live_opportunity_by_id(&self, input: get_opportunities::GetLiveOpportunityByIdInput) -> Option<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+        pub async fn remove_invalid_or_expired_opportunities(&self);
+        pub async fn update_metrics(&self);
+        pub async fn remove_opportunities(
+            &self,
+            input: remove_opportunities::RemoveOpportunitiesInput,
+        ) -> Result<(), crate::api::RestError>;
+        pub async fn add_opportunity(
+            &self,
+            input: add_opportunity::AddOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+        ) -> Result<<T::InMemoryStore as InMemoryStore>::Opportunity, crate::api::RestError>;
+        pub async fn get_opportunities(
+            &self,
+            input: get_opportunities::GetOpportunitiesInput,
+        ) -> Result<Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>, crate::api::RestError>;
+        pub async fn get_quote(&self, input: get_quote::GetQuoteInput) -> Result<crate::opportunity::entities::Quote, crate::api::RestError>;
+        pub async fn handle_opportunity_bid(
+            &self,
+            input: handle_opportunity_bid::HandleOpportunityBidInput,
+        ) -> Result<uuid::Uuid, crate::api::RestError>;
+    }
+    impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
+        async fn verify_opportunity(
+            &self,
+            input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+        ) -> Result<crate::opportunity::entities::OpportunityVerificationResult, crate::api::RestError>;
     }
 }

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -350,11 +350,11 @@ pub mod tests {
 
 #[cfg(test)]
 mock! {
-    pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
+    pub Service<T: ChainType + 'static> {
         pub fn new(
             store: Arc<Store>,
             task_tracker: TaskTracker,
-            db: U,
+            db: DB,
             config: HashMap<ChainId, T::Config>,
         ) -> Self;
         pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
@@ -380,7 +380,7 @@ mock! {
             input: handle_opportunity_bid::HandleOpportunityBidInput,
         ) -> Result<uuid::Uuid, crate::api::RestError>;
     }
-    impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
+    impl<T: ChainType + 'static> verification::Verification<T> for Service<T> {
         async fn verify_opportunity(
             &self,
             input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -347,44 +347,43 @@ pub mod tests {
             (service, ws_receiver)
         }
     }
-}
 
-#[cfg(test)]
-mock! {
-    pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
-        pub fn new(
-            store: Arc<Store>,
-            task_tracker: TaskTracker,
-            db: U,
-            config: HashMap<ChainId, T::Config>,
-        ) -> Self;
-        pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
-        pub async fn get_live_opportunities(&self, input: get_live_opportunities::GetLiveOpportunitiesInput) -> Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>;
-        pub async fn get_live_opportunity_by_id(&self, input: get_opportunities::GetLiveOpportunityByIdInput) -> Option<<T::InMemoryStore as InMemoryStore>::Opportunity>;
-        pub async fn remove_invalid_or_expired_opportunities(&self);
-        pub async fn update_metrics(&self);
-        pub async fn remove_opportunities(
-            &self,
-            input: remove_opportunities::RemoveOpportunitiesInput,
-        ) -> Result<(), crate::api::RestError>;
-        pub async fn add_opportunity(
-            &self,
-            input: add_opportunity::AddOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
-        ) -> Result<<T::InMemoryStore as InMemoryStore>::Opportunity, crate::api::RestError>;
-        pub async fn get_opportunities(
-            &self,
-            input: get_opportunities::GetOpportunitiesInput,
-        ) -> Result<Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>, crate::api::RestError>;
-        pub async fn get_quote(&self, input: get_quote::GetQuoteInput) -> Result<crate::opportunity::entities::Quote, crate::api::RestError>;
-        pub async fn handle_opportunity_bid(
-            &self,
-            input: handle_opportunity_bid::HandleOpportunityBidInput,
-        ) -> Result<uuid::Uuid, crate::api::RestError>;
-    }
-    impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
-        async fn verify_opportunity(
-            &self,
-            input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
-        ) -> Result<crate::opportunity::entities::OpportunityVerificationResult, crate::api::RestError>;
+    mock! {
+        pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
+            pub fn new(
+                store: Arc<Store>,
+                task_tracker: TaskTracker,
+                db: U,
+                config: HashMap<ChainId, T::Config>,
+            ) -> Self;
+            pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
+            pub async fn get_live_opportunities(&self, input: get_live_opportunities::GetLiveOpportunitiesInput) -> Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+            pub async fn get_live_opportunity_by_id(&self, input: get_opportunities::GetLiveOpportunityByIdInput) -> Option<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+            pub async fn remove_invalid_or_expired_opportunities(&self);
+            pub async fn update_metrics(&self);
+            pub async fn remove_opportunities(
+                &self,
+                input: remove_opportunities::RemoveOpportunitiesInput,
+            ) -> Result<(), crate::api::RestError>;
+            pub async fn add_opportunity(
+                &self,
+                input: add_opportunity::AddOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+            ) -> Result<<T::InMemoryStore as InMemoryStore>::Opportunity, crate::api::RestError>;
+            pub async fn get_opportunities(
+                &self,
+                input: get_opportunities::GetOpportunitiesInput,
+            ) -> Result<Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>, crate::api::RestError>;
+            pub async fn get_quote(&self, input: get_quote::GetQuoteInput) -> Result<crate::opportunity::entities::Quote, crate::api::RestError>;
+            pub async fn handle_opportunity_bid(
+                &self,
+                input: handle_opportunity_bid::HandleOpportunityBidInput,
+            ) -> Result<uuid::Uuid, crate::api::RestError>;
+        }
+        impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
+            async fn verify_opportunity(
+                &self,
+                input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+            ) -> Result<crate::opportunity::entities::OpportunityVerificationResult, crate::api::RestError>;
+        }
     }
 }

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use mockall::mock;
 use {
     super::repository::{
         InMemoryStore,
@@ -344,5 +346,45 @@ pub mod tests {
 
             (service, ws_receiver)
         }
+    }
+}
+
+#[cfg(test)]
+mock! {
+    pub Service<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> {
+        pub fn new(
+            store: Arc<Store>,
+            task_tracker: TaskTracker,
+            db: U,
+            config: HashMap<ChainId, T::Config>,
+        ) -> Self;
+        pub fn get_config(&self, chain_id: &ChainId) -> Result<T::Config, crate::api::RestError>;
+        pub async fn get_live_opportunities(&self, input: get_live_opportunities::GetLiveOpportunitiesInput) -> Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+        pub async fn get_live_opportunity_by_id(&self, input: get_opportunities::GetLiveOpportunityByIdInput) -> Option<<T::InMemoryStore as InMemoryStore>::Opportunity>;
+        pub async fn remove_invalid_or_expired_opportunities(&self);
+        pub async fn update_metrics(&self);
+        pub async fn remove_opportunities(
+            &self,
+            input: remove_opportunities::RemoveOpportunitiesInput,
+        ) -> Result<(), crate::api::RestError>;
+        pub async fn add_opportunity(
+            &self,
+            input: add_opportunity::AddOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+        ) -> Result<<T::InMemoryStore as InMemoryStore>::Opportunity, crate::api::RestError>;
+        pub async fn get_opportunities(
+            &self,
+            input: get_opportunities::GetOpportunitiesInput,
+        ) -> Result<Vec<<T::InMemoryStore as InMemoryStore>::Opportunity>, crate::api::RestError>;
+        pub async fn get_quote(&self, input: get_quote::GetQuoteInput) -> Result<crate::opportunity::entities::Quote, crate::api::RestError>;
+        pub async fn handle_opportunity_bid(
+            &self,
+            input: handle_opportunity_bid::HandleOpportunityBidInput,
+        ) -> Result<uuid::Uuid, crate::api::RestError>;
+    }
+    impl<T: ChainType + 'static, U: OpportunityTable<T::InMemoryStore> + 'static> verification::Verification<T> for Service<T, U> {
+        async fn verify_opportunity(
+            &self,
+            input: verification::VerifyOpportunityInput<<<T::InMemoryStore as InMemoryStore>::Opportunity as crate::opportunity::entities::Opportunity>::OpportunityCreate>,
+        ) -> Result<crate::opportunity::entities::OpportunityVerificationResult, crate::api::RestError>;
     }
 }

--- a/auction-server/src/opportunity/workers.rs
+++ b/auction-server/src/opportunity/workers.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::opportunity::service::MockService as Service;
+use crate::opportunity::service::tests::MockService as Service;
 #[cfg(not(test))]
 use crate::opportunity::service::Service;
 use {

--- a/auction-server/src/opportunity/workers.rs
+++ b/auction-server/src/opportunity/workers.rs
@@ -1,12 +1,18 @@
+#[cfg(test)]
+use crate::opportunity::service::MockService as Service;
+#[cfg(not(test))]
+use crate::opportunity::service::Service;
 use {
     super::service::{
         verification::Verification,
         ChainType,
-        Service,
     },
-    crate::server::{
-        EXIT_CHECK_INTERVAL,
-        SHOULD_EXIT,
+    crate::{
+        kernel::db::DB,
+        server::{
+            EXIT_CHECK_INTERVAL,
+            SHOULD_EXIT,
+        },
     },
     std::{
         sync::{
@@ -17,9 +23,9 @@ use {
     },
 };
 
-pub async fn run_verification_loop<T: ChainType>(service: Arc<Service<T>>) -> anyhow::Result<()>
+pub async fn run_verification_loop<T: ChainType>(service: Arc<Service<T, DB>>) -> anyhow::Result<()>
 where
-    Service<T>: Verification<T>,
+    Service<T, DB>: Verification<T>,
 {
     tracing::info!(
         chain_type = ?T::get_type(),

--- a/auction-server/src/opportunity/workers.rs
+++ b/auction-server/src/opportunity/workers.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
-use crate::opportunity::service::tests::MockService as Service;
-#[cfg(not(test))]
-use crate::opportunity::service::Service;
+#[double]
+use super::service::Service;
 use {
     super::service::{
         verification::Verification,
@@ -14,6 +12,7 @@ use {
             SHOULD_EXIT,
         },
     },
+    mockall_double::double,
     std::{
         sync::{
             atomic::Ordering,

--- a/auction-server/src/opportunity/workers.rs
+++ b/auction-server/src/opportunity/workers.rs
@@ -5,12 +5,9 @@ use {
         verification::Verification,
         ChainType,
     },
-    crate::{
-        kernel::db::DB,
-        server::{
-            EXIT_CHECK_INTERVAL,
-            SHOULD_EXIT,
-        },
+    crate::server::{
+        EXIT_CHECK_INTERVAL,
+        SHOULD_EXIT,
     },
     mockall_double::double,
     std::{
@@ -22,9 +19,9 @@ use {
     },
 };
 
-pub async fn run_verification_loop<T: ChainType>(service: Arc<Service<T, DB>>) -> anyhow::Result<()>
+pub async fn run_verification_loop<T: ChainType>(service: Arc<Service<T>>) -> anyhow::Result<()>
 where
-    Service<T, DB>: Verification<T>,
+    Service<T>: Verification<T>,
 {
     tracing::info!(
         chain_type = ?T::get_type(),

--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+use crate::opportunity::service::MockService as OpportunityService;
+#[cfg(not(test))]
+use crate::opportunity::service::Service as OpportunityService;
 use {
     crate::{
         api::{
@@ -17,7 +21,10 @@ use {
             MigrateOptions,
             RunOptions,
         },
-        kernel::traced_sender_svm::TracedSenderSvm,
+        kernel::{
+            db::DB,
+            traced_sender_svm::TracedSenderSvm,
+        },
         models,
         opportunity::{
             service as opportunity_service,
@@ -327,16 +334,18 @@ pub async fn start_server(run_options: RunOptions) -> Result<()> {
         metrics_recorder: setup_metrics_recorder()?,
     });
 
-    let opportunity_service_evm = Arc::new(opportunity_service::Service::<
+    let opportunity_service_evm = Arc::new(OpportunityService::<
         opportunity_service::ChainTypeEvm,
+        DB,
     >::new(
         store.clone(),
         task_tracker.clone(),
         pool.clone(),
         config_opportunity_service_evm,
     ));
-    let opportunity_service_svm = Arc::new(opportunity_service::Service::<
+    let opportunity_service_svm = Arc::new(OpportunityService::<
         opportunity_service::ChainTypeSvm,
+        DB,
     >::new(
         store.clone(),
         task_tracker.clone(),

--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -19,10 +19,7 @@ use {
             MigrateOptions,
             RunOptions,
         },
-        kernel::{
-            db::DB,
-            traced_sender_svm::TracedSenderSvm,
-        },
+        kernel::traced_sender_svm::TracedSenderSvm,
         models,
         opportunity::{
             service as opportunity_service,
@@ -333,24 +330,22 @@ pub async fn start_server(run_options: RunOptions) -> Result<()> {
         metrics_recorder: setup_metrics_recorder()?,
     });
 
-    let opportunity_service_evm = Arc::new(OpportunityService::<
-        opportunity_service::ChainTypeEvm,
-        DB,
-    >::new(
-        store.clone(),
-        task_tracker.clone(),
-        pool.clone(),
-        config_opportunity_service_evm,
-    ));
-    let opportunity_service_svm = Arc::new(OpportunityService::<
-        opportunity_service::ChainTypeSvm,
-        DB,
-    >::new(
-        store.clone(),
-        task_tracker.clone(),
-        pool.clone(),
-        config_opportunity_service_svm,
-    ));
+    let opportunity_service_evm = Arc::new(
+        OpportunityService::<opportunity_service::ChainTypeEvm>::new(
+            store.clone(),
+            task_tracker.clone(),
+            pool.clone(),
+            config_opportunity_service_evm,
+        ),
+    );
+    let opportunity_service_svm = Arc::new(
+        OpportunityService::<opportunity_service::ChainTypeSvm>::new(
+            store.clone(),
+            task_tracker.clone(),
+            pool.clone(),
+            config_opportunity_service_svm,
+        ),
+    );
     #[allow(clippy::iter_kv_map)]
     let mut auction_services: HashMap<ChainId, auction_service::ServiceEnum> = chains_evm
         .iter()

--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -1,6 +1,4 @@
-#[cfg(test)]
-use crate::opportunity::service::tests::MockService as OpportunityService;
-#[cfg(not(test))]
+#[double]
 use crate::opportunity::service::Service as OpportunityService;
 use {
     crate::{
@@ -57,6 +55,7 @@ use {
         future::join_all,
         Future,
     },
+    mockall_double::double,
     solana_client::{
         nonblocking::rpc_client::RpcClient,
         rpc_client::RpcClientConfig,

--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::opportunity::service::MockService as OpportunityService;
+use crate::opportunity::service::tests::MockService as OpportunityService;
 #[cfg(not(test))]
 use crate::opportunity::service::Service as OpportunityService;
 use {

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+use crate::opportunity::service::MockService as OpportunityService;
+#[cfg(not(test))]
+use crate::opportunity::service::Service as OpportunityService;
 use {
     crate::{
         api::{
@@ -10,7 +14,10 @@ use {
             ConfigEvm,
             ConfigSvm,
         },
-        kernel::traced_client::TracedClient,
+        kernel::{
+            db::DB,
+            traced_client::TracedClient,
+        },
         models,
         opportunity::service as opportunity_service,
     },
@@ -136,10 +143,8 @@ pub struct Store {
 }
 
 pub struct StoreNew {
-    pub opportunity_service_evm:
-        Arc<opportunity_service::Service<opportunity_service::ChainTypeEvm>>,
-    pub opportunity_service_svm:
-        Arc<opportunity_service::Service<opportunity_service::ChainTypeSvm>>,
+    pub opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm, DB>>,
+    pub opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm, DB>>,
     pub store:                   Arc<Store>,
 
     auction_services: HashMap<ChainId, auction_service::ServiceEnum>,
@@ -148,12 +153,8 @@ pub struct StoreNew {
 impl StoreNew {
     pub fn new(
         store: Arc<Store>,
-        opportunity_service_evm: Arc<
-            opportunity_service::Service<opportunity_service::ChainTypeEvm>,
-        >,
-        opportunity_service_svm: Arc<
-            opportunity_service::Service<opportunity_service::ChainTypeSvm>,
-        >,
+        opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm, DB>>,
+        opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm, DB>>,
         auction_services: HashMap<ChainId, auction_service::ServiceEnum>,
     ) -> Self {
         Self {

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -1,6 +1,4 @@
-#[cfg(test)]
-use crate::opportunity::service::tests::MockService as OpportunityService;
-#[cfg(not(test))]
+#[double]
 use crate::opportunity::service::Service as OpportunityService;
 use {
     crate::{
@@ -33,6 +31,7 @@ use {
         providers::Provider,
         types::U256,
     },
+    mockall_double::double,
     rand::Rng,
     solana_client::rpc_response::{
         Response,

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::opportunity::service::MockService as OpportunityService;
+use crate::opportunity::service::tests::MockService as OpportunityService;
 #[cfg(not(test))]
 use crate::opportunity::service::Service as OpportunityService;
 use {

--- a/auction-server/src/state.rs
+++ b/auction-server/src/state.rs
@@ -12,10 +12,7 @@ use {
             ConfigEvm,
             ConfigSvm,
         },
-        kernel::{
-            db::DB,
-            traced_client::TracedClient,
-        },
+        kernel::traced_client::TracedClient,
         models,
         opportunity::service as opportunity_service,
     },
@@ -142,8 +139,8 @@ pub struct Store {
 }
 
 pub struct StoreNew {
-    pub opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm, DB>>,
-    pub opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm, DB>>,
+    pub opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm>>,
+    pub opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm>>,
     pub store:                   Arc<Store>,
 
     auction_services: HashMap<ChainId, auction_service::ServiceEnum>,
@@ -152,8 +149,8 @@ pub struct StoreNew {
 impl StoreNew {
     pub fn new(
         store: Arc<Store>,
-        opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm, DB>>,
-        opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm, DB>>,
+        opportunity_service_evm: Arc<OpportunityService<opportunity_service::ChainTypeEvm>>,
+        opportunity_service_svm: Arc<OpportunityService<opportunity_service::ChainTypeSvm>>,
         auction_services: HashMap<ChainId, auction_service::ServiceEnum>,
     ) -> Self {
         Self {


### PR DESCRIPTION
This PR aims to add a test for `verify_bid` function for swap opportunity with mocking every external resource for auction module including opportunity service. The main objective here is mocking the resources not a complete test suit. Later we will add more tests for the function. 