### PR TITLE
feat: close user wsol ata always

### DIFF
--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -115,8 +115,9 @@ pub enum InstructionError {
     InvalidToAccountTransferInstruction { expected: Pubkey, found: Pubkey },
     InvalidAmountTransferInstruction { expected: u64, found: u64 },
     InvalidSyncNativeInstructionCount(Pubkey),
-    InvalidCloseAccountInstructionsCount,
-    InvalidAccountToCloseCloseAccountInstruction { expected: Pubkey, found: Pubkey },
+    InvalidCloseAccountInstructionCountUser(usize),
+    InvalidCloseAccountInstructionCountSearcher(usize),
+    InvalidAccountToCloseCloseAccountInstruction(Pubkey),
     InvalidDestinationCloseAccountInstruction { expected: Pubkey, found: Pubkey },
     InvalidOwnerCloseAccountInstruction { expected: Pubkey, found: Pubkey },
 }
@@ -182,14 +183,17 @@ impl std::fmt::Display for InstructionError {
                     address
                 )
             }
-            InstructionError::InvalidCloseAccountInstructionsCount => {
-                write!(f, "Exactly one close account instruction is required")
+            InstructionError::InvalidCloseAccountInstructionCountUser(found) => {
+                write!(f, "Exactly one close account instruction for the user account was expected, found: {:?}", found)
             }
-            InstructionError::InvalidAccountToCloseCloseAccountInstruction { expected, found } => {
+            InstructionError::InvalidCloseAccountInstructionCountSearcher(found) => {
+                write!(f, "One or less close account instructions for the searcher account were expected, found: {:?}", found)
+            }
+            InstructionError::InvalidAccountToCloseCloseAccountInstruction(ata) => {
                 write!(
                     f,
-                    "Invalid account to close in close account instruction. Expected: {:?} found: {:?}",
-                    found, expected
+                    "Invalid account to close in close account instruction. Tried to close {:?} which doesn't belong to the user nor the searcher",
+                    ata
                 )
             }
             InstructionError::InvalidDestinationCloseAccountInstruction { expected, found } => {

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -117,7 +117,7 @@ pub enum InstructionError {
     InvalidSyncNativeInstructionCount(Pubkey),
     InvalidCloseAccountInstructionCountUser(usize),
     InvalidCloseAccountInstructionCountSearcher(usize),
-    InvalidAccountToCloseCloseAccountInstruction(Pubkey),
+    InvalidAccountToCloseInCloseAccountInstruction(Pubkey),
     InvalidDestinationCloseAccountInstruction { expected: Pubkey, found: Pubkey },
     InvalidOwnerCloseAccountInstruction { expected: Pubkey, found: Pubkey },
 }
@@ -189,7 +189,7 @@ impl std::fmt::Display for InstructionError {
             InstructionError::InvalidCloseAccountInstructionCountSearcher(found) => {
                 write!(f, "One or less close account instructions for the searcher account were expected, found: {:?}", found)
             }
-            InstructionError::InvalidAccountToCloseCloseAccountInstruction(ata) => {
+            InstructionError::InvalidAccountToCloseInCloseAccountInstruction(ata) => {
                 write!(
                     f,
                     "Invalid account to close in close account instruction. Tried to close {:?} which doesn't belong to the user nor the searcher",

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1059,7 +1059,7 @@ impl Service<Svm> {
         if let Some(close_account_instruction) = other_unwrap_sol_instructions.pop() {
             return Err(RestError::InvalidInstruction(
                 None,
-                InstructionError::InvalidAccountToCloseCloseAccountInstruction(
+                InstructionError::InvalidAccountToCloseInCloseAccountInstruction(
                     close_account_instruction.account,
                 ),
             ));
@@ -3363,7 +3363,7 @@ mod tests {
             result.unwrap_err(),
             RestError::InvalidInstruction(
                 None,
-                InstructionError::InvalidAccountToCloseCloseAccountInstruction(found)
+                InstructionError::InvalidAccountToCloseInCloseAccountInstruction(found)
             )
         );
     }
@@ -3985,7 +3985,7 @@ mod tests {
             result.unwrap_err(),
             RestError::InvalidInstruction(
                 None,
-                InstructionError::InvalidAccountToCloseCloseAccountInstruction(found)
+                InstructionError::InvalidAccountToCloseInCloseAccountInstruction(found)
             )
         );
     }

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1030,7 +1030,6 @@ impl Service<Svm> {
         Ok(result)
     }
 
-
     fn check_close_account_instruction(
         tx: &VersionedTransaction,
         swap_accounts: &SwapAccounts,
@@ -1091,6 +1090,7 @@ impl Service<Svm> {
                 }
             } else if swap_accounts.mint_user != spl_token::native_mint::id()
             // for backward compatibility we allow not closing the users account when the user token is wsol, we can remove this if statement once searchers have updated their sdk
+            // at that point we will also update `test_verify_bid_user_wsol` which will fail
             {
                 return Err(RestError::InvalidInstruction(
                     None,

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1066,10 +1066,10 @@ impl Service<Svm> {
             ));
         }
 
-        // User has to unwrap Sol
         if swap_accounts.mint_searcher == spl_token::native_mint::id()
             || swap_accounts.mint_user == spl_token::native_mint::id()
         {
+            // User has to unwrap Sol
             if let Some(close_account_instruction) = user_unwrap_sol_instructions.pop() {
                 if close_account_instruction.destination != swap_accounts.user_wallet {
                     return Err(RestError::InvalidInstruction(
@@ -1108,7 +1108,7 @@ impl Service<Svm> {
                 ));
             }
 
-            // Searcher may want to unwrap but at most once
+            // Searcher may want to unwrap but at most once. We don't care about destination and owner
             if searcher_unwrap_sol_instructions.len() > 1 {
                 return Err(RestError::InvalidInstruction(
                     None,
@@ -3214,7 +3214,7 @@ mod tests {
                 transfer_instruction,
                 sync_native_instruction,
                 swap_instruction,
-                close_account_instruction,
+                close_account_instruction, // <--- this is the only difference from the previous test
             ],
             Some(&searcher.pubkey()),
         );

--- a/sdk/js/src/svm.ts
+++ b/sdk/js/src/svm.ts
@@ -457,7 +457,7 @@ export async function constructSwapBid(
     relayerSigner,
   );
   tx.instructions.push(swapInstruction);
-  if (searcherToken.equals(NATIVE_MINT)) {
+  if (searcherToken.equals(NATIVE_MINT) || userToken.equals(NATIVE_MINT)) {
     tx.instructions.push(getUnwrapSolInstruction(user));
   }
   return {

--- a/sdk/python/express_relay/client.py
+++ b/sdk/python/express_relay/client.py
@@ -792,7 +792,10 @@ class ExpressRelayClient:
             svm_config["express_relay_program"],
         )
         instructions.append(swap_ix)
-        if accs["searcher_token"] == WRAPPED_SOL_MINT:
+        if (
+            accs["searcher_token"] == WRAPPED_SOL_MINT
+            or accs["user_token"] == WRAPPED_SOL_MINT
+        ):
             instructions.append(unwrap_sol(accs["user"]))
         return instructions
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -841,7 +841,7 @@ impl Biddable for api_types::opportunity::OpportunitySvm {
                     fee_receiver_relayer: params.fee_receiver_relayer,
                     relayer_signer:       params.relayer_signer,
                 })?);
-                if searcher_token == native_mint::id() {
+                if searcher_token == native_mint::id() || user_token == native_mint::id() {
                     instructions.push(svm::Svm::get_unwrap_sol_instruction(
                         svm::GetUnwrapSolInstructionParams {
                             owner: user_wallet_address,


### PR DESCRIPTION
I want the searcher sdks to close the user WSOL atas when the user token is WSOL.

The problem: it doesn't pass verification currently.
So we also update the verification in a backward compatible way.
Longterm, we want to enforce the closing of the WSOL ata in this case. 