### PR TITLE
program updates

### DIFF
--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -561,7 +561,10 @@ impl Service<ChainTypeSvm> {
         };
         let compute_fees = |amount: u64| {
             metadata
-                .compute_swap_fees(referral_fee_info.referral_fee_bps, amount)
+                .compute_swap_fees_with_default_platform_fee(
+                    referral_fee_info.referral_fee_bps,
+                    amount,
+                )
                 .map_err(|e| {
                     tracing::error!("Failed to compute swap fees: {:?}", e);
                     RestError::TemporarilyUnavailable

--- a/contracts/svm/programs/express_relay/src/state.rs
+++ b/contracts/svm/programs/express_relay/src/state.rs
@@ -2,21 +2,23 @@ use anchor_lang::prelude::*;
 
 pub const FEE_SPLIT_PRECISION: u64 = 10_000;
 
-pub const RESERVE_EXPRESS_RELAY_METADATA: usize = 8 + 112 + 300;
+pub const RESERVE_EXPRESS_RELAY_METADATA: usize = 8 + 152 + 260;
 pub const SEED_METADATA: &[u8] = b"metadata";
 
 #[account]
 #[derive(Default)]
 pub struct ExpressRelayMetadata {
-    pub admin:                 Pubkey,
-    pub relayer_signer:        Pubkey,
-    pub fee_receiver_relayer:  Pubkey,
+    pub admin:                    Pubkey,
+    pub relayer_signer:           Pubkey,
+    pub fee_receiver_relayer:     Pubkey,
     // the portion of the bid that goes to the router, in bps
-    pub split_router_default:  u64,
+    pub split_router_default:     u64,
     // the portion of the remaining bid (after router fees) that goes to the relayer, in bps
-    pub split_relayer:         u64,
+    pub split_relayer:            u64,
     // the portion of the swap amount that should go to the platform (relayer + express relay), in bps
-    pub swap_platform_fee_bps: u64,
+    pub swap_platform_fee_bps:    u64,
+    // secondary relayer signer, useful for 0-downtime transitioning to a new relayer
+    pub secondary_relayer_signer: Pubkey,
 }
 
 pub const RESERVE_EXPRESS_RELAY_CONFIG_ROUTER: usize = 8 + 40 + 200;

--- a/contracts/svm/programs/express_relay/src/swap.rs
+++ b/contracts/svm/programs/express_relay/src/swap.rs
@@ -161,6 +161,7 @@ impl ExpressRelayMetadata {
         if !self.relayer_signer.eq(relayer_signer)
             && !self.secondary_relayer_signer.eq(relayer_signer)
         {
+            // TODO: change to a better error code
             return Err(AnchorErrorCode::ConstraintHasOne.into());
         }
         Ok(())

--- a/contracts/svm/programs/express_relay/src/token.rs
+++ b/contracts/svm/programs/express_relay/src/token.rs
@@ -9,9 +9,28 @@ use {
     },
 };
 
+pub fn get_token_account_checked(
+    account: &AccountInfo,
+    expected_program_id: &Pubkey,
+) -> Result<TokenAccount> {
+    if account.data_len() == 0 {
+        return Err(ErrorCode::AccountNotInitialized.into());
+    }
+
+    if account.owner != expected_program_id {
+        return Err(ErrorCode::ConstraintOwner.into());
+    }
+
+    let token_account = match TokenAccount::try_deserialize(&mut &account.data.borrow()[..]) {
+        Ok(ta) => ta,
+        Err(_) => return Err(ErrorCode::ConstraintTokenTokenProgram.into()),
+    };
+
+    Ok(token_account)
+}
 pub fn transfer_token_if_needed<'info>(
     from: &InterfaceAccount<'info, TokenAccount>,
-    to: &InterfaceAccount<'info, TokenAccount>,
+    to: AccountInfo<'info>,
     token_program: &Interface<'info, TokenInterface>,
     authority: &Signer<'info>,
     mint: &InterfaceAccount<'info, Mint>,
@@ -29,6 +48,41 @@ pub fn transfer_token_if_needed<'info>(
             CpiContext::new(token_program.to_account_info(), cpi_accounts),
             amount,
             mint.decimals,
+        )?;
+    }
+    Ok(())
+}
+
+pub fn check_receiver_and_transfer_token_if_needed<'info>(
+    from: &InterfaceAccount<'info, TokenAccount>,
+    recipient_token_account: &UncheckedAccount<'info>,
+    recipient: Option<&Pubkey>,
+    token_program: &Interface<'info, TokenInterface>,
+    authority: &Signer<'info>,
+    mint: &InterfaceAccount<'info, Mint>,
+    amount: u64,
+) -> Result<()> {
+    if amount > 0 {
+        let to = get_token_account_checked(
+            &recipient_token_account.to_account_info(),
+            &token_program.key(),
+        )?;
+
+        if let Some(recipient) = recipient {
+            if !to.owner.eq(recipient) {
+                return Err(ErrorCode::ConstraintTokenOwner.into());
+            }
+        }
+        if !to.mint.eq(&mint.key()) {
+            return Err(ErrorCode::ConstraintTokenMint.into());
+        }
+        transfer_token_if_needed(
+            from,
+            recipient_token_account.to_account_info(),
+            token_program,
+            authority,
+            mint,
+            amount,
         )?;
     }
     Ok(())

--- a/contracts/svm/programs/express_relay/src/token.rs
+++ b/contracts/svm/programs/express_relay/src/token.rs
@@ -18,12 +18,12 @@ pub fn get_token_account_checked(
     }
 
     if account.owner != expected_program_id {
-        return Err(ErrorCode::ConstraintOwner.into());
+        return Err(ErrorCode::ConstraintTokenTokenProgram.into());
     }
 
     let token_account = match TokenAccount::try_deserialize(&mut &account.data.borrow()[..]) {
         Ok(ta) => ta,
-        Err(_) => return Err(ErrorCode::ConstraintTokenTokenProgram.into()),
+        Err(_) => return Err(ErrorCode::AccountDidNotDeserialize.into()),
     };
 
     Ok(token_account)

--- a/contracts/svm/programs/express_relay/src/token.rs
+++ b/contracts/svm/programs/express_relay/src/token.rs
@@ -38,9 +38,9 @@ pub fn transfer_token_if_needed<'info>(
 ) -> Result<()> {
     if amount > 0 {
         let cpi_accounts = TransferChecked {
-            from:      from.to_account_info(),
-            to:        to.to_account_info(),
-            mint:      mint.to_account_info(),
+            from: from.to_account_info(),
+            to,
+            mint: mint.to_account_info(),
             authority: authority.to_account_info(),
         };
 

--- a/contracts/svm/testing/src/express_relay/mod.rs
+++ b/contracts/svm/testing/src/express_relay/mod.rs
@@ -3,6 +3,7 @@ pub mod initialize;
 pub mod set_admin;
 pub mod set_relayer;
 pub mod set_router_split;
+pub mod set_secondary_relayer;
 pub mod set_splits;
 pub mod set_swap_platform_fee;
 pub mod submit_bid;

--- a/contracts/svm/testing/src/express_relay/set_secondary_relayer.rs
+++ b/contracts/svm/testing/src/express_relay/set_secondary_relayer.rs
@@ -1,0 +1,32 @@
+use {
+    super::helpers::get_express_relay_metadata_key,
+    anchor_lang::{
+        InstructionData,
+        ToAccountMetas,
+    },
+    express_relay::accounts::SetSecondaryRelayer,
+    solana_sdk::{
+        instruction::Instruction,
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+    },
+};
+
+pub fn set_secondary_relayer_instruction(
+    admin: &Keypair,
+    secondary_relayer_signer: Pubkey,
+) -> Instruction {
+    let express_relay_metadata = get_express_relay_metadata_key();
+
+    Instruction {
+        program_id: express_relay::id(),
+        data:       express_relay::instruction::SetSecondaryRelayer {}.data(),
+        accounts:   SetSecondaryRelayer {
+            admin: admin.pubkey(),
+            express_relay_metadata,
+            secondary_relayer_signer,
+        }
+        .to_account_metas(None),
+    }
+}

--- a/contracts/svm/testing/tests/set_secondary_relayer.rs
+++ b/contracts/svm/testing/tests/set_secondary_relayer.rs
@@ -1,0 +1,71 @@
+use {
+    anchor_lang::error::ErrorCode as AnchorErrorCode,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+    },
+    testing::{
+        express_relay::{
+            helpers::get_express_relay_metadata,
+            set_secondary_relayer::set_secondary_relayer_instruction,
+        },
+        helpers::{
+            assert_custom_error,
+            generate_and_fund_key,
+            submit_transaction,
+        },
+        setup::setup,
+    },
+};
+
+#[test]
+fn test_set_secondary_relayer() {
+    let setup_result = setup(None).expect("setup failed");
+
+    let mut svm = setup_result.svm;
+    let admin = setup_result.admin;
+
+    let primary_relayer_signer = get_express_relay_metadata(&mut svm).relayer_signer;
+
+    let secondary_relayer_signer_new = Pubkey::new_unique();
+    let set_secondary_relayer_ix =
+        set_secondary_relayer_instruction(&admin, secondary_relayer_signer_new);
+    submit_transaction(&mut svm, &[set_secondary_relayer_ix], &admin, &[&admin])
+        .expect("Transaction failed unexpectedly");
+
+    let express_relay_metadata = get_express_relay_metadata(&mut svm);
+
+    assert_eq!(
+        express_relay_metadata.secondary_relayer_signer,
+        secondary_relayer_signer_new
+    );
+    assert_eq!(
+        express_relay_metadata.relayer_signer,
+        primary_relayer_signer
+    );
+}
+
+#[test]
+fn test_set_secondary_relayer_fail_wrong_admin() {
+    let setup_result = setup(None).expect("setup failed");
+
+    let mut svm = setup_result.svm;
+    let wrong_admin = generate_and_fund_key(&mut svm);
+
+    let relayer_signer_new = Pubkey::new_unique();
+    let set_secondary_relayer_ix =
+        set_secondary_relayer_instruction(&wrong_admin, relayer_signer_new);
+    let tx_result = submit_transaction(
+        &mut svm,
+        &[set_secondary_relayer_ix],
+        &wrong_admin,
+        &[&wrong_admin],
+    )
+    .expect_err("Transaction should have failed");
+
+    assert_custom_error(
+        tx_result.err,
+        0,
+        InstructionError::Custom(AnchorErrorCode::ConstraintHasOne.into()),
+    );
+}


### PR DESCRIPTION
Changes:
- Add a secondary relayer for 0-downtime transitions between relayers
- Relax ata constraints on fee receivers: Only check their existence if the fees are positive
- Add a new instruction where swap fee bps is determined by the input

Tests to add:
- Assert second relayer works
- Test custom fees
- Test not checking atas when fees are 0

Next steps:
- Deploy program
- Accepting both instructions on the server side
- Update SDKs to use the new instruction
- Disallow the older swap instruction
- Configurable fees