### PR TITLE
fix: 0 length accounts

### DIFF
--- a/auction-server/src/opportunity/service/get_quote_request_account_balances.rs
+++ b/auction-server/src/opportunity/service/get_quote_request_account_balances.rs
@@ -196,7 +196,10 @@ impl Service<ChainTypeSvm> {
                 account
                     .as_ref()
                     .map(|acc| {
-                        StateWithExtensions::<TokenAccount>::unpack(&acc.data[..TokenAccount::LEN])
+                        if acc.data.is_empty() {
+                            return Ok(0);
+                        }
+                        StateWithExtensions::<TokenAccount>::unpack(&acc.data)
                             .map_err(|err| {
                                 tracing::error!(error = ?err, "Failed to deserialize a token account");
                                 RestError::TemporarilyUnavailable

--- a/auction-server/src/opportunity/service/get_quote_request_account_balances.rs
+++ b/auction-server/src/opportunity/service/get_quote_request_account_balances.rs
@@ -196,7 +196,8 @@ impl Service<ChainTypeSvm> {
                 account
                     .as_ref()
                     .map(|acc| {
-                        if acc.data.is_empty() {
+                        if acc.data.is_empty()  // Accounts can "exist" (because someone has sent SOL to them) but be uninitialized, this handles that case
+                        {
                             return Ok(0);
                         }
                         StateWithExtensions::<TokenAccount>::unpack(&acc.data)


### PR DESCRIPTION
atas can sometimes be uninitialized but exist (when someone has airdropped some sol to the address for example)
