### PR TITLE
feat: Improve important service call instrumentation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -157,7 +157,7 @@ local_resource(
 )
 
 monitor_command = (
-    "source tilt-resources.env; "
+    "source ./tilt-resources.env; "
     + "poetry -C tilt-scripts run "
     + "python3 -m tilt-scripts.protocols.token_vault_monitor "
     + "--chain-id development "
@@ -231,7 +231,7 @@ local_resource(
 )
 
 rust_searcher_command = (
-    "source tilt-resources.env;"
+    "source ./tilt-resources.env;"
     + "export SVM_PRIVATE_KEY_FILE=keypairs/searcher_rust.json;"
     + "cargo run -p testing-searcher -- --api-key=$(poetry -C tilt-scripts run python3 tilt-scripts/utils/create_profile.py --name rust_sdk --email rust_sdk@dourolabs.com --role searcher)"
 )

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -69,6 +69,10 @@ use {
     },
     spl_associated_token_account::instruction::AssociatedTokenAccountInstruction,
     std::{
+        fmt::{
+            Display,
+            Formatter,
+        },
         sync::{
             atomic::Ordering,
             Arc,
@@ -564,6 +568,12 @@ impl IntoResponse for RestError {
     fn into_response(self) -> Response {
         let (status, msg) = self.to_status_and_message();
         (status, Json(ErrorBodyResponse { error: msg })).into_response()
+    }
+}
+
+impl Display for RestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_status_and_message().1)
     }
 }
 

--- a/auction-server/src/auction/repository/add_bid.rs
+++ b/auction-server/src/auction/repository/add_bid.rs
@@ -16,6 +16,7 @@ use {
 };
 
 impl<T: ChainTrait> Repository<T> {
+    #[tracing::instrument(skip_all, err)]
     pub async fn add_bid(
         &self,
         bid_create: entities::BidCreate<T>,

--- a/auction-server/src/auction/service/cancel_bid.rs
+++ b/auction-server/src/auction/service/cancel_bid.rs
@@ -18,6 +18,7 @@ pub struct CancelBidInput {
 }
 
 impl Service<Svm> {
+    #[tracing::instrument(skip_all, err)]
     async fn cancel_bid_for_lock(
         &self,
         input: CancelBidInput,
@@ -57,6 +58,7 @@ impl Service<Svm> {
         }
     }
 
+    #[tracing::instrument(skip_all, err)]
     pub async fn cancel_bid(&self, input: CancelBidInput) -> Result<(), RestError> {
         // Lock the bid to prevent submission
         let bid_lock = self

--- a/auction-server/src/auction/service/get_bid.rs
+++ b/auction-server/src/auction/service/get_bid.rs
@@ -14,6 +14,7 @@ pub struct GetBidInput {
 }
 
 impl<T: ChainTrait> Service<T> {
+    #[tracing::instrument(skip_all, err)]
     pub async fn get_bid(&self, input: GetBidInput) -> Result<entities::Bid<T>, RestError> {
         self.repo.get_bid(input.bid_id).await
     }

--- a/auction-server/src/auction/service/get_bids.rs
+++ b/auction-server/src/auction/service/get_bids.rs
@@ -17,6 +17,7 @@ pub struct GetBidsInput {
 }
 
 impl<T: ChainTrait> Service<T> {
+    #[tracing::instrument(skip_all, err)]
     pub async fn get_bids(&self, input: GetBidsInput) -> Result<Vec<entities::Bid<T>>, RestError> {
         self.repo.get_bids(input.profile.id, input.from_time).await
     }

--- a/auction-server/src/auction/service/handle_auction.rs
+++ b/auction-server/src/auction/service/handle_auction.rs
@@ -27,7 +27,7 @@ impl<T: ChainTrait> Service<T>
 where
     Service<T>: AuctionManager<T>,
 {
-    #[tracing::instrument(skip_all, fields(auction_id, bid_ids, winner_bid_ids))]
+    #[tracing::instrument(skip_all, fields(auction_id, bid_ids, winner_bid_ids), err)]
     async fn submit_auction<'a>(
         &self,
         auction: entities::Auction<T>,

--- a/auction-server/src/auction/service/handle_bid.rs
+++ b/auction-server/src/auction/service/handle_bid.rs
@@ -23,7 +23,8 @@ where
 {
     #[tracing::instrument(
         skip_all,
-        fields(bid_id, profile_name, simulation_error, permission_key)
+        fields(bid_id, profile_name, simulation_error, permission_key),
+        err
     )]
     pub async fn handle_bid(
         &self,

--- a/auction-server/src/auction/service/submit_quote.rs
+++ b/auction-server/src/auction/service/submit_quote.rs
@@ -92,6 +92,7 @@ impl Service<Svm> {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, err)]
     pub async fn submit_quote(
         &self,
         input: SubmitQuoteInput,

--- a/auction-server/src/auction/service/update_bid_status.rs
+++ b/auction-server/src/auction/service/update_bid_status.rs
@@ -19,7 +19,7 @@ pub struct UpdateBidStatusInput<T: ChainTrait> {
 }
 
 impl<T: ChainTrait> Service<T> {
-    #[tracing::instrument(skip_all, fields(bid_id, status))]
+    #[tracing::instrument(skip_all, fields(bid_id, status), err)]
     pub async fn update_bid_status(
         &self,
         input: UpdateBidStatusInput<T>,

--- a/auction-server/src/auction/service/update_recent_prioritization_fee.rs
+++ b/auction-server/src/auction/service/update_recent_prioritization_fee.rs
@@ -14,6 +14,7 @@ impl Service<Svm> {
     /// For each of the last 150 slots, client returns the `config.prioritization_fee_percentile`th percentile
     /// of prioritization fees for transactions that landed in that slot.
     /// The median of such values for the `RECENT_FEES_SLOT_WINDOW` most recent slots is returned.
+    #[tracing::instrument(skip_all, err)]
     pub async fn update_recent_prioritization_fee(&self) -> Result<u64, RestError> {
         let accounts: Vec<String> = vec![];
         let mut args: Vec<serde_json::Value> = vec![

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -257,6 +257,7 @@ impl Verification<Evm> for Service<Evm> {
     // 1. The bid amount should cover gas fees for all bids included in the submission.
     // 2. Depending on the maximum number of bids in the auction, the transaction size for the bid is limited.
     // 3. Depending on the maximum number of bids in the auction, the gas consumption for the bid is limited.
+    #[tracing::instrument(skip_all, err)]
     async fn verify_bid(
         &self,
         input: VerifyBidInput<Evm>,
@@ -1705,6 +1706,7 @@ impl Service<Svm> {
 
 #[async_trait]
 impl Verification<Svm> for Service<Svm> {
+    #[tracing::instrument(skip_all, err)]
     async fn verify_bid(
         &self,
         input: VerifyBidInput<Svm>,


### PR DESCRIPTION
# About
This PR adds extra instrumentation decorators to important service calls to allow better tracking of failures, we currently fall back to the API style stringification of errors, as an improvement one might one to create separate tracing stringifications for Errors that have even more information.

# Testing
tested manually via observing the new otel traces.