### PR TITLE
fix: don't crash for big values

### DIFF
--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -727,7 +727,9 @@ export class Client {
             opportunity.token_account_initialization_configs.user_ata_mint_user,
         },
         memo: opportunity.memo ?? undefined,
-        userMintUserBalance: new anchor.BN(opportunity.user_mint_user_balance),
+        userMintUserBalance: new anchor.BN(
+          opportunity.user_mint_user_balance.toString(),
+        ),
       };
     } else {
       console.warn("Unsupported opportunity", opportunity);


### PR DESCRIPTION
The BN constructor would crash if `user_mint_user_balance` is too big to warn the user `number` is not precise after a certain magnitude.

This doesn't fix the loss of precision problem, but at least it doesn't crash anymore 
