### PR TITLE
feat: Add ppm precision to swap v2 fees

### DIFF
--- a/contracts/svm/programs/express_relay/src/lib.rs
+++ b/contracts/svm/programs/express_relay/src/lib.rs
@@ -455,11 +455,11 @@ pub struct SwapV2Args {
     pub deadline:              i64,
     pub amount_searcher:       u64,
     pub amount_user:           u64,
-    /// The referral fee is specified in mill percentile
+    /// The referral fee is specified in parts per million
     pub referral_fee_ppm:      u64,
     /// Token in which the fees will be paid
     pub fee_token:             FeeToken,
-    /// The platform fee is specified in mill percentile
+    /// The platform fee is specified in parts per million
     pub swap_platform_fee_ppm: u64,
 }
 
@@ -524,12 +524,12 @@ pub struct Swap<'info> {
     pub mint_searcher: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(mint::token_program = token_program_user)]
-    /// CHECK: we check that this is set correctly based on the fee token manually since the V2 arguments are incompatible on the wire
     pub mint_user: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         mint::token_program = token_program_fee,
     )]
+    /// CHECK: we check that this is set correctly based on the fee token manually since the V2 arguments are incompatible on the wire
     pub mint_fee: Box<InterfaceAccount<'info, Mint>>,
 
     // Token programs

--- a/contracts/svm/programs/express_relay/src/lib.rs
+++ b/contracts/svm/programs/express_relay/src/lib.rs
@@ -182,8 +182,8 @@ pub mod express_relay {
         )
     }
 
-
     pub fn swap_internal(ctx: Context<Swap>, data: SwapV2Args) -> Result<()> {
+        ctx.accounts.check_raw_constraints(data.fee_token)?;
         check_deadline(data.deadline)?;
         ctx.accounts
             .express_relay_metadata
@@ -227,6 +227,7 @@ pub mod express_relay {
 
         Ok(())
     }
+
     pub fn swap(ctx: Context<Swap>, data: SwapArgs) -> Result<()> {
         let data = ctx.accounts.convert_to_v2(&data);
         swap_internal(ctx, data)
@@ -438,31 +439,31 @@ pub struct SwapArgs {
 impl SwapArgs {
     pub fn convert_to_v2(&self, swap_platform_fee_bps: u64) -> SwapV2Args {
         SwapV2Args {
-            deadline: self.deadline,
-            amount_searcher: self.amount_searcher,
-            amount_user: self.amount_user,
-            fee_token: self.fee_token,
-            referral_fee_bps: self.referral_fee_bps,
-            swap_platform_fee_bps,
+            deadline:              self.deadline,
+            amount_searcher:       self.amount_searcher,
+            amount_user:           self.amount_user,
+            fee_token:             self.fee_token,
+            referral_fee_ppm:      u64::from(self.referral_fee_bps) * FEE_BPS_TO_PPM,
+            swap_platform_fee_ppm: swap_platform_fee_bps * FEE_BPS_TO_PPM,
         }
     }
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Eq, PartialEq, Clone, Copy, Debug)]
 pub struct SwapV2Args {
-    // deadline as a unix timestamp in seconds
+    /// deadline as a unix timestamp in seconds
     pub deadline:              i64,
     pub amount_searcher:       u64,
     pub amount_user:           u64,
-    // The referral fee is specified in basis points
-    pub referral_fee_bps:      u16,
-    // Token in which the fees will be paid
+    /// The referral fee is specified in mill percentile
+    pub referral_fee_ppm:      u64,
+    /// Token in which the fees will be paid
     pub fee_token:             FeeToken,
-    pub swap_platform_fee_bps: u64,
+    /// The platform fee is specified in mill percentile
+    pub swap_platform_fee_ppm: u64,
 }
 
 #[derive(Accounts)]
-#[instruction(data: Box<SwapArgs>)]
 pub struct Swap<'info> {
     /// Searcher is the party that fulfills the quote request
     pub searcher: Signer<'info>,
@@ -523,11 +524,11 @@ pub struct Swap<'info> {
     pub mint_searcher: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(mint::token_program = token_program_user)]
+    /// CHECK: we check that this is set correctly based on the fee token manually since the V2 arguments are incompatible on the wire
     pub mint_user: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         mint::token_program = token_program_fee,
-        constraint = mint_fee.key() == if data.fee_token == FeeToken::Searcher { mint_searcher.key() } else { mint_user.key() }
     )]
     pub mint_fee: Box<InterfaceAccount<'info, Mint>>,
 
@@ -535,9 +536,7 @@ pub struct Swap<'info> {
     pub token_program_searcher: Interface<'info, TokenInterface>,
     pub token_program_user:     Interface<'info, TokenInterface>,
 
-    #[account(
-        constraint = token_program_fee.key() == if data.fee_token == FeeToken::Searcher { token_program_searcher.key() } else { token_program_user.key() }
-    )]
+    /// CHECK: we check that this is set correctly based on the fee token manually since the V2 arguments are incompatible on the wire
     pub token_program_fee: Interface<'info, TokenInterface>,
 
     /// Express relay configuration

--- a/contracts/svm/programs/express_relay/src/state.rs
+++ b/contracts/svm/programs/express_relay/src/state.rs
@@ -2,8 +2,8 @@ use anchor_lang::prelude::*;
 
 pub const FEE_SPLIT_PRECISION: u64 = 10_000;
 
-pub const FEE_SPLIT_PRECISION_PPM: u64 = 100_000_000;
-pub const FEE_BPS_TO_PPM: u64 = 10_000;
+pub const FEE_SPLIT_PRECISION_PPM: u64 = 1_000_000;
+pub const FEE_BPS_TO_PPM: u64 = 100;
 
 pub const RESERVE_EXPRESS_RELAY_METADATA: usize = 8 + 152 + 260;
 pub const SEED_METADATA: &[u8] = b"metadata";

--- a/contracts/svm/programs/express_relay/src/state.rs
+++ b/contracts/svm/programs/express_relay/src/state.rs
@@ -2,6 +2,9 @@ use anchor_lang::prelude::*;
 
 pub const FEE_SPLIT_PRECISION: u64 = 10_000;
 
+pub const FEE_SPLIT_PRECISION_PPM: u64 = 100_000_000;
+pub const FEE_BPS_TO_PPM: u64 = 10_000;
+
 pub const RESERVE_EXPRESS_RELAY_METADATA: usize = 8 + 152 + 260;
 pub const SEED_METADATA: &[u8] = b"metadata";
 

--- a/contracts/svm/testing/tests/swap.rs
+++ b/contracts/svm/testing/tests/swap.rs
@@ -177,58 +177,40 @@ fn test_swap_fee_mint_searcher(args: SwapSetupParams) {
     let express_relay_metadata = get_express_relay_metadata(&mut svm);
 
     // searcher token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_searcher.get_associated_token_address(&searcher.pubkey()),
-        token_searcher.get_amount_with_decimals(10.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_searcher,
-        token_searcher.get_amount_with_decimals(0.),
-    ));
+        token_searcher,
+        {
+            associated: {
+                searcher.pubkey() => 10.0,
+                user.pubkey() => 0.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_searcher => 0.0,
+            }
+        }
+    );
+
 
     // user token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_user.get_associated_token_address(&searcher.pubkey()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(10.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_user,
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_user.get_amount_with_decimals(0.),
-    ));
+        token_user,
+        {
+            associated: {
+                searcher.pubkey() => 0.0,
+                user.pubkey() => 10.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_user => 0.0,
+            }
+        }
+    );
+
 
     // searcher token fee
     let swap_args = SwapArgs {
@@ -258,58 +240,39 @@ fn test_swap_fee_mint_searcher(args: SwapSetupParams) {
     .unwrap();
 
     // searcher token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_searcher.get_associated_token_address(&searcher.pubkey()),
-        token_searcher.get_amount_with_decimals(9.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&user.pubkey()),
-        token_searcher.get_amount_with_decimals(0.6),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_searcher.get_amount_with_decimals(0.08),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_searcher.get_amount_with_decimals(0.02),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_searcher,
-        token_searcher.get_amount_with_decimals(0.3),
-    ));
+        token_searcher,
+        {
+            associated: {
+                searcher.pubkey() => 9.0,
+                user.pubkey() => 0.6,
+                get_express_relay_metadata_key() => 0.08,
+                express_relay_metadata.fee_receiver_relayer => 0.02,
+            },
+            raw: {
+                router_ta_mint_searcher => 0.3,
+            }
+        }
+    );
+
 
     // user token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_user.get_associated_token_address(&searcher.pubkey()),
-        token_user.get_amount_with_decimals(1.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(9.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_user,
-        token_user.get_amount_with_decimals(0.),
-    ));
+        token_user,
+        {
+            associated: {
+                searcher.pubkey() => 1.0,
+                user.pubkey() => 9.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_user => 0.0,
+            }
+        }
+    );
 }
 
 fn test_swap_fee_mint_user(args: SwapSetupParams) {
@@ -328,58 +291,39 @@ fn test_swap_fee_mint_user(args: SwapSetupParams) {
     let express_relay_metadata = get_express_relay_metadata(&mut svm);
 
     // searcher token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_searcher.get_associated_token_address(&searcher.pubkey()),
-        token_searcher.get_amount_with_decimals(10.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_searcher,
-        token_searcher.get_amount_with_decimals(0.),
-    ));
+        token_searcher,
+        {
+            associated: {
+                searcher.pubkey() => 10.0,
+                user.pubkey() => 0.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_searcher => 0.0,
+            }
+        }
+    );
+
 
     // user token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_user.get_associated_token_address(&searcher.pubkey()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(10.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_user,
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_user.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_user.get_amount_with_decimals(0.),
-    ));
+        token_user,
+        {
+            associated: {
+                searcher.pubkey() => 0.0,
+                user.pubkey() => 10.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_user => 0.0,
+            }
+        }
+    );
 
     let swap_args = SwapArgs {
         deadline:         svm.get_sysvar::<Clock>().unix_timestamp,
@@ -409,58 +353,39 @@ fn test_swap_fee_mint_user(args: SwapSetupParams) {
     .unwrap();
 
     // searcher token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_searcher.get_associated_token_address(&searcher.pubkey()),
-        token_searcher.get_amount_with_decimals(9.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&user.pubkey()),
-        token_searcher.get_amount_with_decimals(1.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_searcher.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_searcher.get_amount_with_decimals(0.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_searcher,
-        token_searcher.get_amount_with_decimals(0.),
-    ));
+        token_searcher,
+        {
+            associated: {
+                searcher.pubkey() => 9.0,
+                user.pubkey() => 1.0,
+                get_express_relay_metadata_key() => 0.0,
+                express_relay_metadata.fee_receiver_relayer => 0.0,
+            },
+            raw: {
+                router_ta_mint_searcher => 0.0,
+            }
+        }
+    );
+
 
     // user token balances
-    assert!(Token::token_balance_matches(
+    assert_all_token_balances!(
         &mut svm,
-        &token_user.get_associated_token_address(&searcher.pubkey()),
-        token_user.get_amount_with_decimals(0.75),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&user.pubkey()),
-        token_user.get_amount_with_decimals(9.),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&get_express_relay_metadata_key()),
-        token_user.get_amount_with_decimals(0.08),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &token_user.get_associated_token_address(&express_relay_metadata.fee_receiver_relayer),
-        token_user.get_amount_with_decimals(0.02),
-    ));
-    assert!(Token::token_balance_matches(
-        &mut svm,
-        &router_ta_mint_user,
-        token_user.get_amount_with_decimals(0.15),
-    ));
+        token_user,
+        {
+            associated: {
+                searcher.pubkey() => 0.75,
+                user.pubkey() => 9.0,
+                get_express_relay_metadata_key() => 0.08,
+                express_relay_metadata.fee_receiver_relayer => 0.02,
+            },
+            raw: {
+                router_ta_mint_user => 0.15,
+            }
+        }
+    );
 }
 
 #[test]
@@ -1529,9 +1454,9 @@ fn test_swap_v2_mint_searcher() {
         deadline:              svm.get_sysvar::<Clock>().unix_timestamp,
         amount_searcher:       token_searcher.get_amount_with_decimals(1.),
         amount_user:           token_user.get_amount_with_decimals(1.),
-        referral_fee_ppm:      30_000_000,
+        referral_fee_ppm:      300_000,
         fee_token:             FeeToken::Searcher,
-        swap_platform_fee_ppm: 20_000_000,
+        swap_platform_fee_ppm: 200_000,
     };
     let instructions = build_swap_instructions(SwapParams {
         searcher: searcher.pubkey(),
@@ -1644,9 +1569,9 @@ fn test_swap_v2_mint_user() {
         deadline:              svm.get_sysvar::<Clock>().unix_timestamp,
         amount_searcher:       token_searcher.get_amount_with_decimals(1.),
         amount_user:           token_user.get_amount_with_decimals(1.),
-        referral_fee_ppm:      15_000_000,
+        referral_fee_ppm:      150_000,
         fee_token:             FeeToken::User,
-        swap_platform_fee_ppm: 20_000_000,
+        swap_platform_fee_ppm: 200_000,
     };
 
     let instructions = build_swap_instructions(SwapParams {
@@ -1808,13 +1733,13 @@ fn test_swap_v2_mint_user_ppm_fee() {
         token_user,
         {
             associated: {
-                searcher.pubkey() => 9999.618900,
+                searcher.pubkey() => 9961.8900,
                 user.pubkey() => 90000.0,
-                get_express_relay_metadata_key() => 0.177760,
-                express_relay_metadata.fee_receiver_relayer => 0.044440,
+                get_express_relay_metadata_key() => 17.7760,
+                express_relay_metadata.fee_receiver_relayer => 4.4440,
             },
             raw: {
-                router_ta_mint_user => 0.158900,
+                router_ta_mint_user => 15.8900,
             }
         }
     );
@@ -1913,12 +1838,12 @@ fn test_swap_v2_mint_searcher_ppm_fee() {
         {
             associated: {
                 searcher.pubkey() => 90000.0,
-                user.pubkey() => 9999.618900,
-                get_express_relay_metadata_key() => 0.177760,
-                express_relay_metadata.fee_receiver_relayer => 0.044440,
+                user.pubkey() => 9961.89,
+                get_express_relay_metadata_key() => 17.7760,
+                express_relay_metadata.fee_receiver_relayer => 4.4440,
             },
             raw: {
-                router_ta_mint_searcher => 0.158900,
+                router_ta_mint_searcher => 15.8900,
             }
         }
     );


### PR DESCRIPTION
# About
In this PR i increased the possible precision for the dynamic platform and referrer fees.
This required a bit of trickery hence the swap v2 account still used the swap v1 argument instruction data, so that the two implementations could share a context. Which has to broken here because the size of the referer fee ppm needs to be increased to u64 from u16 breaking wire compatibility. This introduces some duplication. The hack were the constraints are moved out of the account validator don't work because the instruction data still needs to deserialize properly even if we werent using fee token data.