### PR TITLE
Add dynamic deadline to quote

### DIFF
--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -348,6 +348,12 @@ pub enum OpportunityParamsV1ProgramSvm {
         /// If provided, this memo must be included in the bid transaction as a Memo program instruction.
         #[schema(example = "memo")]
         memo: Option<String>,
+
+        /// The quote deadline (in seconds) must be at least this many seconds later than the time the request is received by the server.
+        /// A value like `10` means the deadline must be at least 10 seconds after the request is received.
+        /// To ensure the deadline is valid, take into account possible network latency, server-side processing delays, and potential clock drift on-chain when setting this value.
+        #[schema(example = 10, value_type = u32)]
+        minimum_lifetime: u32,
     },
 }
 
@@ -579,7 +585,7 @@ pub struct QuoteCreateV1SvmParams {
     /// The chain id for creating the quote.
     #[schema(example = "solana", value_type = String)]
     pub chain_id:               ChainId,
-    /// Optional memo to be included in the transaction
+    /// Optional memo to be included in the transaction.
     #[schema(example = "memo")]
     pub memo:                   Option<String>,
     /// Whether the quote is cancellable by the searcher between the time the quote is requested and the time the quote is signed and submitted back.
@@ -588,6 +594,9 @@ pub struct QuoteCreateV1SvmParams {
     #[schema(example = "true")]
     #[serde(default = "default_cancellable")]
     pub cancellable:            bool,
+    /// Optional minimum transaction lifetime in seconds.
+    #[schema(example = 10, value_type = Option<u32>)]
+    pub minimum_lifetime:       Option<u32>,
 }
 
 fn default_cancellable() -> bool {

--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -351,7 +351,7 @@ pub enum OpportunityParamsV1ProgramSvm {
 
         /// The quote deadline (in seconds) must be at least this many seconds later than the time the request is received by the server.
         /// A value like `10` means the deadline must be at least 10 seconds after the request is received.
-        /// To ensure the deadline is valid, take into account possible network latency, server-side processing delays, and potential clock drift on-chain when setting this value.
+        /// To ensure the deadline is reasonable, take into account possible network latency, auction and submission delays.
         #[schema(example = 10, value_type = u32)]
         minimum_lifetime: u32,
     },

--- a/auction-server/src/opportunity/entities/opportunity_svm.rs
+++ b/auction-server/src/opportunity/entities/opportunity_svm.rs
@@ -10,7 +10,10 @@ use {
         OpportunityCreate,
     },
     crate::{
-        auction::entities::BidPaymentInstructionType,
+        auction::{
+            entities::BidPaymentInstructionType,
+            service::verification::DEFAULT_SWAP_BID_MINIMUM_LIFE_TIME,
+        },
         kernel::entities::PermissionKey,
         opportunity::{
             entities::QuoteTokens,
@@ -104,6 +107,7 @@ pub struct OpportunitySvmProgramSwap {
     pub token_program_searcher:               Pubkey,
     pub token_account_initialization_configs: TokenAccountInitializationConfigs,
     pub memo:                                 Option<String>,
+    pub minimum_lifetime:                     Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -173,6 +177,7 @@ impl Opportunity for OpportunitySvm {
                             .token_account_initialization_configs,
                         user_mint_user_balance:               program.user_mint_user_balance,
                         memo:                                 program.memo,
+                        minimum_lifetime:                     program.minimum_lifetime,
                     },
                 )
             }
@@ -396,6 +401,9 @@ impl From<OpportunitySvm> for api::OpportunitySvm {
                         .token_account_initialization_configs
                         .into(),
                     memo: program.memo,
+                    minimum_lifetime: program
+                        .minimum_lifetime
+                        .unwrap_or(DEFAULT_SWAP_BID_MINIMUM_LIFE_TIME),
                 }
             }
         };
@@ -452,6 +460,7 @@ impl TryFrom<repository::Opportunity<repository::OpportunityMetadataSvm>> for Op
                         .token_account_initialization_configs,
                     user_mint_user_balance:               program.user_mint_user_balance,
                     memo:                                 program.memo,
+                    minimum_lifetime:                     program.minimum_lifetime,
                 })
             }
         };

--- a/auction-server/src/opportunity/entities/quote.rs
+++ b/auction-server/src/opportunity/entities/quote.rs
@@ -42,6 +42,7 @@ pub struct QuoteCreate {
     pub chain_id:            ChainId,
     pub memo:                Option<String>,
     pub cancellable:         bool,
+    pub minimum_lifetime:    Option<u32>,
 }
 
 
@@ -130,6 +131,7 @@ impl From<api::QuoteCreate> for QuoteCreate {
             chain_id: params.chain_id,
             memo: params.memo,
             cancellable: params.cancellable,
+            minimum_lifetime: params.minimum_lifetime,
         }
     }
 }

--- a/auction-server/src/opportunity/repository/models.rs
+++ b/auction-server/src/opportunity/repository/models.rs
@@ -99,6 +99,7 @@ pub struct OpportunityMetadataSvmProgramSwap {
     pub user_mint_user_balance:               u64,
     pub token_account_initialization_configs: TokenAccountInitializationConfigs,
     pub memo:                                 Option<String>,
+    pub minimum_lifetime:                     Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -351,6 +351,7 @@ impl Service<ChainTypeSvm> {
                 token_account_initialization_configs,
                 token_program_searcher,
                 memo: quote_create.memo,
+                minimum_lifetime: quote_create.minimum_lifetime,
             });
 
         Ok(entities::OpportunityCreateSvm {


### PR DESCRIPTION
This PR introduces a `minimum_lifetime` parameter for `get_quote` requests. It allows the Protocol to optimize pricing by requesting quotes with varying deadline windows, either shorter or longer, based on its strategy.