### PR TITLE
Feat: add metrics around deadline validation

### DIFF
--- a/auction-server/src/auction/service/submit_quote.rs
+++ b/auction-server/src/auction/service/submit_quote.rs
@@ -17,7 +17,7 @@ use {
         },
         per_metrics::{
             SUBMIT_QUOTE_DEADLINE_BUFFER_METRIC,
-            SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
+            SUBMIT_QUOTE_DEADLINE_TOTAL,
         },
     },
     axum_prometheus::metrics,
@@ -141,7 +141,7 @@ impl Service<Svm> {
 
         if deadline_buffer_secs < MIN_DEADLINE_BUFFER_SECS {
             metrics::counter!(
-                SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
+                SUBMIT_QUOTE_DEADLINE_TOTAL,
                 &[
                     ("chain_id", chain_id.clone()),
                     ("result", "error".to_string()),
@@ -152,7 +152,7 @@ impl Service<Svm> {
         }
 
         metrics::counter!(
-            SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
+            SUBMIT_QUOTE_DEADLINE_TOTAL,
             &[("chain_id", chain_id), ("result", "success".to_string()),]
         )
         .increment(1);

--- a/auction-server/src/auction/service/submit_quote.rs
+++ b/auction-server/src/auction/service/submit_quote.rs
@@ -15,6 +15,10 @@ use {
             ChainId,
             Svm,
         },
+        per_metrics::{
+            SUBMIT_QUOTE_DEADLINE_BUFFER_METRIC,
+            SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
+        },
     },
     axum_prometheus::metrics,
     solana_sdk::{
@@ -129,17 +133,15 @@ impl Service<Svm> {
     ) -> Result<(), RestError> {
         let deadline_buffer_secs = swap_args.deadline - OffsetDateTime::now_utc().unix_timestamp();
 
-        tracing::info!("Deadline buffer: {}", deadline_buffer_secs);
-
         metrics::histogram!(
-            "submit_quote_deadline_buffer",
+            SUBMIT_QUOTE_DEADLINE_BUFFER_METRIC,
             &[("chain_id", chain_id.clone()),]
         )
         .record(deadline_buffer_secs as f64);
 
         if deadline_buffer_secs < MIN_DEADLINE_BUFFER_SECS {
             metrics::counter!(
-                "submit_quote_deadline_check",
+                SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
                 &[
                     ("chain_id", chain_id.clone()),
                     ("result", "error".to_string()),
@@ -150,7 +152,7 @@ impl Service<Svm> {
         }
 
         metrics::counter!(
-            "submit_quote_deadline_check",
+            SUBMIT_QUOTE_DEADLINE_CHECK_METRIC,
             &[("chain_id", chain_id), ("result", "success".to_string()),]
         )
         .increment(1);

--- a/auction-server/src/auction/service/submit_quote.rs
+++ b/auction-server/src/auction/service/submit_quote.rs
@@ -11,13 +11,16 @@ use {
             self,
             BidStatus,
         },
-        kernel::entities::Svm,
+        kernel::entities::{
+            ChainId,
+            Svm,
+        },
     },
+    axum_prometheus::metrics,
     solana_sdk::{
         signature::Signature,
         transaction::VersionedTransaction,
     },
-    std::time::Duration,
     time::OffsetDateTime,
 };
 
@@ -26,7 +29,7 @@ pub struct SubmitQuoteInput {
     pub user_signature: Signature,
 }
 
-const DEADLINE_BUFFER: Duration = Duration::from_secs(2);
+const MIN_DEADLINE_BUFFER_SECS: i64 = 2;
 
 impl Service<Svm> {
     async fn get_bid_to_submit(
@@ -119,6 +122,41 @@ impl Service<Svm> {
         Ok(())
     }
 
+    fn check_deadline_buffer(
+        &self,
+        chain_id: ChainId,
+        swap_args: express_relay::SwapArgs,
+    ) -> Result<(), RestError> {
+        let deadline_buffer_secs = swap_args.deadline - OffsetDateTime::now_utc().unix_timestamp();
+
+        tracing::info!("Deadline buffer: {}", deadline_buffer_secs);
+
+        metrics::histogram!(
+            "submit_quote_deadline_buffer",
+            &[("chain_id", chain_id.clone()),]
+        )
+        .record(deadline_buffer_secs as f64);
+
+        if deadline_buffer_secs < MIN_DEADLINE_BUFFER_SECS {
+            metrics::counter!(
+                "submit_quote_deadline_check",
+                &[
+                    ("chain_id", chain_id.clone()),
+                    ("result", "error".to_string()),
+                ]
+            )
+            .increment(1);
+            return Err(RestError::BadParameters("Quote is expired.".to_string()));
+        }
+
+        metrics::counter!(
+            "submit_quote_deadline_check",
+            &[("chain_id", chain_id), ("result", "success".to_string()),]
+        )
+        .increment(1);
+        Ok(())
+    }
+
     #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE), fields(bid_id, auction_id = %input.auction_id))]
     pub async fn submit_quote(
         &self,
@@ -141,9 +179,7 @@ impl Service<Svm> {
         let swap_args = Self::extract_swap_data(&swap_instruction)
             .map_err(|_| RestError::BadParameters("Invalid quote.".to_string()))?;
 
-        if swap_args.deadline < (OffsetDateTime::now_utc() - DEADLINE_BUFFER).unix_timestamp() {
-            return Err(RestError::BadParameters("Quote is expired.".to_string()));
-        }
+        self.check_deadline_buffer(auction.chain_id.clone(), swap_args)?;
 
         if !input.user_signature.verify(
             &user_wallet.to_bytes(),

--- a/auction-server/src/per_metrics.rs
+++ b/auction-server/src/per_metrics.rs
@@ -49,7 +49,7 @@ pub const SUBMIT_QUOTE_DEADLINE_BUFFER_BUCKETS: &[f64; 20] = &[
     -5.0, -2.0, -1.0, 0.0, 1.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0,
     30.0, 50.0,
 ];
-pub const SUBMIT_QUOTE_DEADLINE_CHECK_METRIC: &str = "submit_quote_deadline_check";
+pub const SUBMIT_QUOTE_DEADLINE_TOTAL: &str = "submit_quote_deadline_total";
 
 #[derive(Debug, Clone)]
 pub struct MetricsLayerData {

--- a/auction-server/src/per_metrics.rs
+++ b/auction-server/src/per_metrics.rs
@@ -44,6 +44,13 @@ pub const TRANSACTION_LANDING_TIME_SVM_BUCKETS: &[f64; 16] = &[
     0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 3.75, 5.0, 10.0, 20.0, 40.0,
 ];
 
+pub const SUBMIT_QUOTE_DEADLINE_BUFFER_METRIC: &str = "submit_quote_deadline_buffer";
+pub const SUBMIT_QUOTE_DEADLINE_BUFFER_BUCKETS: &[f64; 20] = &[
+    -5.0, -2.0, -1.0, 0.0, 1.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0,
+    30.0, 50.0,
+];
+pub const SUBMIT_QUOTE_DEADLINE_CHECK_METRIC: &str = "submit_quote_deadline_check";
+
 #[derive(Debug, Clone)]
 pub struct MetricsLayerData {
     category:   String,

--- a/auction-server/src/server.rs
+++ b/auction-server/src/server.rs
@@ -172,6 +172,13 @@ pub fn setup_metrics_recorder() -> Result<PrometheusHandle> {
             per_metrics::TRANSACTION_LANDING_TIME_SVM_BUCKETS,
         )
         .unwrap()
+        .set_buckets_for_metric(
+            axum_prometheus::metrics_exporter_prometheus::Matcher::Full(
+                per_metrics::SUBMIT_QUOTE_DEADLINE_BUFFER_METRIC.to_string(),
+            ),
+            per_metrics::SUBMIT_QUOTE_DEADLINE_BUFFER_BUCKETS,
+        )
+        .unwrap()
         .set_buckets(DEFAULT_METRICS_BUCKET)
         .unwrap()
         .install_recorder()


### PR DESCRIPTION
This PR adds some metrics around the validation of the deadline in `submit_quote`. This will help to track the rate of swaps failing due to late submission.