### PR TITLE
Fix issue regarding expired bids without auction id

### DIFF
--- a/auction-server/.sqlx/query-12869f012538d108ee2a3e9c98ad91daf52246ba0ebad020330288d05ac5b3c9.json
+++ b/auction-server/.sqlx/query-12869f012538d108ee2a3e9c98ad91daf52246ba0ebad020330288d05ac5b3c9.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -39,8 +39,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-8a16817295ec17dda1e25c36141b51f4ac67966f57636e9df36222263552c10f.json
+++ b/auction-server/.sqlx/query-8a16817295ec17dda1e25c36141b51f4ac67966f57636e9df36222263552c10f.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -39,8 +39,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -59,8 +59,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -79,8 +79,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-9526c7c80829a0dbeea7763b3381467782c8bec86f6f8b52fe11325b96edbdb4.json
+++ b/auction-server/.sqlx/query-9526c7c80829a0dbeea7763b3381467782c8bec86f6f8b52fe11325b96edbdb4.json
@@ -32,8 +32,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-a25adc19c687c4988ca108b2ef7dedeafe298047458c91bf3bf0540274c4c508.json
+++ b/auction-server/.sqlx/query-a25adc19c687c4988ca108b2ef7dedeafe298047458c91bf3bf0540274c4c508.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -39,8 +39,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-b54b6d2c1d4d7957fb7188eec17ec8a0b4e7ab51c728bac77f79ffbd896d8c27.json
+++ b/auction-server/.sqlx/query-b54b6d2c1d4d7957fb7188eec17ec8a0b4e7ab51c728bac77f79ffbd896d8c27.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -38,8 +38,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-d8d976f022e66635ab32c56b9fda9ac97b4e7ef55ec3dc11bde044fc248998be.json
+++ b/auction-server/.sqlx/query-d8d976f022e66635ab32c56b9fda9ac97b4e7ef55ec3dc11bde044fc248998be.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -38,8 +38,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -58,8 +58,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -78,8 +78,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-e57e8bee9fbc6c2c16396d0900f44a734f7cfc94637ff3a8f1b52a329a704522.json
+++ b/auction-server/.sqlx/query-e57e8bee9fbc6c2c16396d0900f44a734f7cfc94637ff3a8f1b52a329a704522.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -38,8 +38,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/.sqlx/query-f934e0aa512da01aef0c1ca76bbd48eb8a5a4983af42287088887ac3e7d6e496.json
+++ b/auction-server/.sqlx/query-f934e0aa512da01aef0c1ca76bbd48eb8a5a4983af42287088887ac3e7d6e496.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE bid SET status = $1, conclusion_time = $2 WHERE id = $3 AND status IN ($4, $5, $6, $7)",
+  "query": "UPDATE bid SET status = $1, conclusion_time = $2, auction_id = $3 WHERE id = $4 AND status IN ($5, $6, $7, $8)",
   "describe": {
     "columns": [],
     "parameters": {
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -26,6 +26,7 @@
           }
         },
         "Timestamp",
+        "Uuid",
         "Uuid",
         {
           "Custom": {
@@ -38,8 +39,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -58,8 +59,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -78,8 +79,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -98,8 +99,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -111,5 +112,5 @@
     },
     "nullable": []
   },
-  "hash": "b9ce3a739e775f73af93da31d45044493fd2b8c67e85dea6331bef2621a558be"
+  "hash": "f934e0aa512da01aef0c1ca76bbd48eb8a5a4983af42287088887ac3e7d6e496"
 }

--- a/auction-server/.sqlx/query-fa6d4023356c380d05db09464366e432a314051f152854620bd2dfcbd66434e2.json
+++ b/auction-server/.sqlx/query-fa6d4023356c380d05db09464366e432a314051f152854620bd2dfcbd66434e2.json
@@ -16,8 +16,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -38,8 +38,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"
@@ -58,8 +58,8 @@
                 "won",
                 "expired",
                 "failed",
-                "awaiting_signature",
                 "cancelled",
+                "awaiting_signature",
                 "sent_to_user_for_submission",
                 "submission_failed_cancelled",
                 "submission_failed_deadline_passed"

--- a/auction-server/migrations/20250508113043_fix_expired_bid_status.down.sql
+++ b/auction-server/migrations/20250508113043_fix_expired_bid_status.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/auction-server/migrations/20250508113043_fix_expired_bid_status.up.sql
+++ b/auction-server/migrations/20250508113043_fix_expired_bid_status.up.sql
@@ -1,0 +1,4 @@
+UPDATE bid
+SET status = 'lost'
+WHERE status = 'expired'
+  AND auction_id IS NULL;

--- a/auction-server/src/auction/repository/models.rs
+++ b/auction-server/src/auction/repository/models.rs
@@ -349,11 +349,12 @@ impl Svm {
                 BidStatus::Submitted as _,
                 BidStatus::SentToUserForSubmission as _,
             )),
-            &entities::BidStatusSvm::Expired { .. } => Ok(sqlx::query!(
-                "UPDATE bid SET status = $1, conclusion_time = $2 WHERE id = $3 AND status IN ($4, $5, $6, $7)",
+            entities::BidStatusSvm::Expired { auction } => Ok(sqlx::query!(
+                "UPDATE bid SET status = $1, conclusion_time = $2, auction_id = $3 WHERE id = $4 AND status IN ($5, $6, $7, $8)",
                 BidStatus::Expired as _,
                 PrimitiveDateTime::new(now.date(), now.time()),
                 bid.id,
+                auction.id,
                 BidStatus::Pending as _,
                 BidStatus::Submitted as _,
                 BidStatus::AwaitingSignature as _,

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -432,6 +432,7 @@ impl Service {
         )
     )]
     pub async fn get_quote(&self, input: GetQuoteInput) -> Result<entities::Quote, RestError> {
+        println!("hello dani0");
         let referral_fee_info = self.unwrap_referral_fee_info(
             input.quote_create.referral_fee_info.clone(),
             &input.quote_create.chain_id,
@@ -469,8 +470,10 @@ impl Service {
             ));
         }
 
+        println!("hello dani1");
         // Wait to make sure searchers had enough time to submit bids
         sleep(config.auction_time).await;
+        println!("hello dani2");
 
         // NOTE: This part will be removed after refactoring the permission key type
         let slice: [u8; 65] = opportunity
@@ -558,10 +561,11 @@ impl Service {
             .await?;
         tracing::Span::current().record("auction_id", auction.id.to_string());
 
+        println!("hello dani3");
         // Remove opportunity to prevent further bids
         // The handle auction loop will take care of the bids that were submitted late
         self.remove_quote_opportunity(opportunity.clone()).await;
-
+        println!("hello dani4");
         let signature = winner_bid.chain_data.transaction.signatures[0];
         // Update the status of all bids in the auction except the winner bid
         let auction_bids = auction.bids.clone();
@@ -588,6 +592,7 @@ impl Service {
                 });
             }
         });
+        println!("hello dani5");
 
         let new_status = if input.quote_create.cancellable {
             BidStatusSvm::AwaitingSignature {
@@ -617,6 +622,7 @@ impl Service {
             // TODO We should handle this case more gracefully
             return Err(RestError::DuplicateOpportunity);
         }
+        println!("hello dani6");
 
         let metadata = self
             .get_express_relay_metadata(GetExpressRelayMetadataInput {

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -432,7 +432,6 @@ impl Service {
         )
     )]
     pub async fn get_quote(&self, input: GetQuoteInput) -> Result<entities::Quote, RestError> {
-        println!("hello dani0");
         let referral_fee_info = self.unwrap_referral_fee_info(
             input.quote_create.referral_fee_info.clone(),
             &input.quote_create.chain_id,
@@ -470,10 +469,8 @@ impl Service {
             ));
         }
 
-        println!("hello dani1");
         // Wait to make sure searchers had enough time to submit bids
         sleep(config.auction_time).await;
-        println!("hello dani2");
 
         // NOTE: This part will be removed after refactoring the permission key type
         let slice: [u8; 65] = opportunity
@@ -561,11 +558,10 @@ impl Service {
             .await?;
         tracing::Span::current().record("auction_id", auction.id.to_string());
 
-        println!("hello dani3");
         // Remove opportunity to prevent further bids
         // The handle auction loop will take care of the bids that were submitted late
         self.remove_quote_opportunity(opportunity.clone()).await;
-        println!("hello dani4");
+
         let signature = winner_bid.chain_data.transaction.signatures[0];
         // Update the status of all bids in the auction except the winner bid
         let auction_bids = auction.bids.clone();
@@ -592,7 +588,6 @@ impl Service {
                 });
             }
         });
-        println!("hello dani5");
 
         let new_status = if input.quote_create.cancellable {
             BidStatusSvm::AwaitingSignature {
@@ -622,7 +617,6 @@ impl Service {
             // TODO We should handle this case more gracefully
             return Err(RestError::DuplicateOpportunity);
         }
-        println!("hello dani6");
 
         let metadata = self
             .get_express_relay_metadata(GetExpressRelayMetadataInput {


### PR DESCRIPTION
This PR aims to fix issues regarding the expired bids without auction id. The migration should take around 10 seconds on Production DB. the total number of affecting rows are less than 3K.