### PR TITLE
fix: increase Clickhouse db throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.32.1"
+version = "0.32.2"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.32.1"
+version = "0.32.2"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/src/kernel/analytics_db.rs
+++ b/auction-server/src/kernel/analytics_db.rs
@@ -10,10 +10,10 @@ pub struct ClickhouseInserter<T> {
     pub sender: mpsc::Sender<T>,
 }
 
-const CHANNEL_SIZE: usize = 5000;
+const CHANNEL_SIZE: usize = 10_000;
 const DURATION_PERIOD: Duration = Duration::from_secs(1);
-const MAX_ROWS: u64 = 1000;
-const MAX_BYTES: u64 = 5 * 1_048_576; // 5 MB
+const MAX_ROWS: u64 = 10_000;
+const MAX_BYTES: u64 = 10 * 1_048_576; // 10 MB
 
 impl<T: Row + Serialize + Send + Sync + 'static> ClickhouseInserter<T> {
     async fn run(client: clickhouse::Client, table_name: String, mut rx: mpsc::Receiver<T>) {

--- a/auction-server/src/kernel/analytics_db.rs
+++ b/auction-server/src/kernel/analytics_db.rs
@@ -10,10 +10,10 @@ pub struct ClickhouseInserter<T> {
     pub sender: mpsc::Sender<T>,
 }
 
-const CHANNEL_SIZE: usize = 1000;
+const CHANNEL_SIZE: usize = 5000;
 const DURATION_PERIOD: Duration = Duration::from_secs(1);
-const MAX_ROWS: u64 = 100;
-const MAX_BYTES: u64 = 1_048_576;
+const MAX_ROWS: u64 = 1000;
+const MAX_BYTES: u64 = 5 * 1_048_576; // 5 MB
 
 impl<T: Row + Serialize + Send + Sync + 'static> ClickhouseInserter<T> {
     async fn run(client: clickhouse::Client, table_name: String, mut rx: mpsc::Receiver<T>) {


### PR DESCRIPTION
This PR increases the throughput to Clickhouse to accommodate the observed backpressure.