### PR TITLE
feat: add minimum platform fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "express-relay-client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "borsh 1.5.5",
  "express-relay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "express-relay-api-types"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/api-types/Cargo.toml
+++ b/auction-server/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "express-relay-api-types"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Pyth Express Relay api types"
 repository = "https://github.com/pyth-network/per"

--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -228,7 +228,7 @@ pub enum OpportunityParamsV1ProgramSvm {
         #[deprecated = "This field is deprecated and will be removed in a future release."]
         // TODO this should be deleted
         /// The referral fee in basis points.
-        #[schema(example = 10, deprecated)]
+        #[schema(example = 10)]
         referral_fee_bps: u16,
 
         /// The referral fee in parts per million.

--- a/auction-server/api-types/src/opportunity.rs
+++ b/auction-server/api-types/src/opportunity.rs
@@ -225,15 +225,17 @@ pub enum OpportunityParamsV1ProgramSvm {
         #[serde_as(as = "DisplayFromStr")]
         router_account: Pubkey,
 
+        #[deprecated = "This field is deprecated and will be removed in a future release."]
         // TODO this should be deleted
         /// The referral fee in basis points.
-        #[schema(example = 10)]
+        #[schema(example = 10, deprecated)]
         referral_fee_bps: u16,
 
         /// The referral fee in parts per million.
         #[schema(example = 1000)]
         referral_fee_ppm: u64,
 
+        #[deprecated = "This field is deprecated and will be removed in a future release."]
         // TODO this should be deleted
         /// The platform fee in basis points.
         #[schema(example = 10)]

--- a/auction-server/config.sample.yaml
+++ b/auction-server/config.sample.yaml
@@ -30,7 +30,7 @@ chains:
         - So11111111111111111111111111111111111111112
         - EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
     allow_permissionless_quote_requests: true
-    minimum_fee_list:
+    minimum_referral_fee_list:
       profiles:
         - profile_id: 0b059fa2-189f-4498-a646-e7ee1ed79c3c
           minimum_fees:
@@ -38,6 +38,10 @@ chains:
               fee_ppm: 100
             - mint: So11111111111111111111111111111111111111112
               fee_ppm: 200
+    minimum_platform_fee_list:
+      minimum_fees:
+        - mint: So11111111111111111111111111111111111111112
+          fee_ppm: 100
 
 lazer:
   price_feeds:

--- a/auction-server/src/api.rs
+++ b/auction-server/src/api.rs
@@ -376,7 +376,7 @@ impl std::fmt::Display for SwapInstructionError {
             ),
             SwapInstructionError::ReferralFee { expected, found } => write!(
                 f,
-                "Invalid referral fee bps {} in swap instruction data. Value does not match the referral fee bps in swap opportunity {}",
+                "Invalid referral fee ppm {} in swap instruction data. Value does not match the referral fee ppm in swap opportunity {}",
                 found, expected
             ),
             SwapInstructionError::AssociatedRouterTokenAccount { expected, found } => write!(

--- a/auction-server/src/config.rs
+++ b/auction-server/src/config.rs
@@ -175,9 +175,12 @@ pub struct ConfigSvm {
     /// Whitelisted token mints
     #[serde(default)]
     pub token_whitelist:                     TokenWhitelistConfig,
-    /// Minimum fee list
+    /// Minimum referral fee list
     #[serde(default)]
-    pub minimum_fee_list:                    MinimumFeeListConfig,
+    pub minimum_referral_fee_list:           MinimumReferralFeeListConfig,
+    /// Minimum platform fee list
+    #[serde(default)]
+    pub minimum_platform_fee_list:           MinimumPlatformFeeListConfig,
     /// Whether to allow permissionless quote requests.
     #[serde(default)]
     pub allow_permissionless_quote_requests: bool,
@@ -207,12 +210,20 @@ pub struct TokenWhitelistConfig {
     pub whitelist_mints: Vec<Pubkey>,
 }
 
-/// Optional minimum fee list to determine validity of quote request
+/// Minimum referral fee list to determine validity of quote request
 #[serde_as]
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-pub struct MinimumFeeListConfig {
+pub struct MinimumReferralFeeListConfig {
     #[serde(default)]
     pub profiles: Vec<MinimumFeeProfile>,
+}
+
+/// Minimum platform fee list to determine platform fees to apply to quote requests
+#[serde_as]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct MinimumPlatformFeeListConfig {
+    #[serde(default)]
+    pub minimum_fees: Vec<MinimumFee>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]

--- a/auction-server/src/opportunity/service/mod.rs
+++ b/auction-server/src/opportunity/service/mod.rs
@@ -264,27 +264,18 @@ impl ConfigSvm {
     }
 
     pub fn get_platform_fee_ppm(&self, mint_user: &Pubkey, mint_searcher: &Pubkey) -> Option<u64> {
-        let fee_user = self.minimum_platform_fee_list.iter().find_map(|fee| {
-            if &fee.mint == mint_user {
-                Some(fee.fee_ppm)
-            } else {
-                None
-            }
-        });
-        let fee_searcher = self.minimum_platform_fee_list.iter().find_map(|fee| {
-            if &fee.mint == mint_searcher {
-                Some(fee.fee_ppm)
-            } else {
-                None
-            }
-        });
+        let fee_user = self
+            .minimum_platform_fee_list
+            .iter()
+            .find(|fee| &fee.mint == mint_user)
+            .map(|fee| fee.fee_ppm);
+        let fee_searcher = self
+            .minimum_platform_fee_list
+            .iter()
+            .find(|fee| &fee.mint == mint_searcher)
+            .map(|fee| fee.fee_ppm);
 
-        match (fee_user, fee_searcher) {
-            (Some(user_fee), Some(searcher_fee)) => Some(max(user_fee, searcher_fee)),
-            (Some(user_fee), None) => Some(user_fee),
-            (None, Some(searcher_fee)) => Some(searcher_fee),
-            (None, None) => None,
-        }
+        fee_user.into_iter().chain(fee_searcher).max()
     }
 }
 

--- a/integration.py
+++ b/integration.py
@@ -42,7 +42,7 @@ chains:
         - {mint_sell}
         - So11111111111111111111111111111111111111112
     allow_permissionless_quote_requests: true
-    minimum_fee_list:
+    minimum_referral_fee_list:
       profiles:
         - profile_id: 4b4f8bcf-415a-4509-be21-bd803cdc8937
           minimum_fees:
@@ -50,6 +50,12 @@ chains:
               fee_ppm: 200
             - mint: {mint_sell}
               fee_ppm: 0
+    minimum_platform_fee_list:
+      minimum_fees:
+        - mint: {mint_buy}
+          fee_ppm: 100
+        - mint: {mint_sell}
+          fee_ppm: 1099
 lazer:
   price_feeds:
     - id: 1

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "express-relay-client"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Pyth Express Relay client"
 repository = "https://github.com/pyth-network/per"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/pyth-network/per"
 license = "Apache-2.0"
 
 [dependencies]
-express-relay-api-types = { version = "0.12.0", path = "../../auction-server/api-types" }
+express-relay-api-types = { version = "0.12.1", path = "../../auction-server/api-types" }
 reqwest = { version = "0.12.9", features = ["json"] }
 url = { workspace = true}
 serde = { workspace = true }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -657,7 +657,6 @@ impl Client {
     /// # Returns
     ///
     /// * `Result<BidCreate, ClientError>` - A bid creation object or an error.
-    #[allow(deprecated)]
     pub async fn new_bid(
         &self,
         opportunity: api_types::opportunity::OpportunitySvm,
@@ -704,7 +703,7 @@ impl Client {
                 tokens,
                 fee_token,
                 router_account,
-                referral_fee_bps,
+                referral_fee_ppm,
                 token_account_initialization_configs,
                 memo,
                 ..
@@ -756,7 +755,7 @@ impl Client {
                         fee_token_program,
                         router_account,
                         fee_receiver_relayer: params.fee_receiver_relayer,
-                        referral_fee_bps,
+                        referral_fee_ppm,
                         chain_id: opportunity_params.chain_id.clone(),
                         configs: token_account_initialization_configs.clone(),
                     },

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -657,6 +657,7 @@ impl Client {
     /// # Returns
     ///
     /// * `Result<BidCreate, ClientError>` - A bid creation object or an error.
+    #[allow(deprecated)]
     pub async fn new_bid(
         &self,
         opportunity: api_types::opportunity::OpportunitySvm,

--- a/sdk/rust/src/svm.rs
+++ b/sdk/rust/src/svm.rs
@@ -303,6 +303,7 @@ impl Svm {
             .collect()
     }
 
+    #[allow(deprecated)]
     fn extract_swap_data(
         opportunity_params: &OpportunityParamsSvm,
     ) -> Result<OpportunitySwapData, ClientError> {

--- a/tilt-scripts/svm/test_swap.py
+++ b/tilt-scripts/svm/test_swap.py
@@ -60,11 +60,16 @@ async def send_and_submit_quote(
     logger.info("Taker pubkey: %s", pk_taker)
     payload = {
         "chain_id": chain_id,
-        "input_token_mint": input_token,
-        "output_token_mint": output_token,
-        "router": "3hv8L8UeBbyM3M25dF3h2C5p8yA4FptD7FFZu4Z1jCMn",
-        "referral_fee_bps": 10,
-        "specified_token_amount": {"amount": random.randint(1, 1000), "side": side},
+        "input_token_mint": output_token,
+        "output_token_mint": input_token,
+        "referral_fee_info": {
+            "referral_fee_ppm": 1000,
+            "router": "3hv8L8UeBbyM3M25dF3h2C5p8yA4FptD7FFZu4Z1jCMn",
+        },
+        "specified_token_amount": {
+            "amount": random.randint(100001, 1000000),
+            "side": side,
+        },
         "user_wallet_address": str(pk_taker),
         "memo": "memo",
         "version": "v1",


### PR DESCRIPTION
This PR adds a minimum platform fees list to the config and parses it to apply platform fees based on token mints.

In order to release this feature, we need to

- [ ] migrate searchers over to using `swap_v2` instead of `swap`
- [ ] ensure searchers are specifying `platform_fee_ppm` there
- [x] update the Rust SDK to perform this correctly

Longer term, we ought to

- [ ] remove the bps fields from the APIs