### PR TITLE
Chore: scale down traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.34.0"
+version = "0.34.1"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/src/auction/repository/add_auction.rs
+++ b/auction-server/src/auction/repository/add_auction.rs
@@ -4,7 +4,6 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all)]
     async fn add_in_memory_auction(&self, auction: entities::Auction) {
         self.in_memory_store
             .auctions
@@ -14,12 +13,10 @@ impl Repository {
     }
 
     // NOTE: Do not call this function directly. Instead call `add_auction` from `Service`.
-    #[tracing::instrument(skip_all, name = "add_auction_repo", fields(auction_id))]
     pub async fn add_auction(
         &self,
         auction: entities::Auction,
     ) -> anyhow::Result<entities::Auction> {
-        tracing::Span::current().record("auction_id", auction.id.to_string());
         self.db.add_auction(&auction).await?;
 
         self.remove_in_memory_pending_bids(auction.bids.as_slice())

--- a/auction-server/src/auction/repository/add_bid.rs
+++ b/auction-server/src/auction/repository/add_bid.rs
@@ -12,7 +12,6 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     pub async fn add_bid(
         &self,
         bid_create: entities::BidCreate,

--- a/auction-server/src/auction/repository/add_bid_analytics.rs
+++ b/auction-server/src/auction/repository/add_bid_analytics.rs
@@ -28,7 +28,6 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     pub async fn add_bid_analytics(
         &self,
         bid: entities::Bid,

--- a/auction-server/src/auction/repository/conclude_auction.rs
+++ b/auction-server/src/auction/repository/conclude_auction.rs
@@ -6,9 +6,7 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, name = "conclude_auction_repo", fields(auction_id))]
     pub async fn conclude_auction(&self, auction_id: entities::AuctionId) -> anyhow::Result<()> {
-        tracing::Span::current().record("auction_id", auction_id.to_string());
         self.db.conclude_auction(auction_id).await?;
         self.remove_in_memory_auction(auction_id).await;
         Ok(())

--- a/auction-server/src/auction/repository/get_or_create_in_memory_bid_lock.rs
+++ b/auction-server/src/auction/repository/get_or_create_in_memory_bid_lock.rs
@@ -4,7 +4,6 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all)]
     pub async fn get_or_create_in_memory_bid_lock(
         &self,
         key: entities::BidId,

--- a/auction-server/src/auction/repository/remove_in_memory_auction.rs
+++ b/auction-server/src/auction/repository/remove_in_memory_auction.rs
@@ -4,9 +4,7 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, fields(auction_id))]
     pub async fn remove_in_memory_auction(&self, auction_id: entities::AuctionId) {
-        tracing::Span::current().record("auction_id", auction_id.to_string());
         self.in_memory_store
             .auctions
             .write()

--- a/auction-server/src/auction/repository/submit_auction.rs
+++ b/auction-server/src/auction/repository/submit_auction.rs
@@ -5,16 +5,12 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, name = "submit_auction_repo", fields(auction_id, tx_hash))]
     pub async fn submit_auction(
         &self,
         auction: entities::Auction,
         transaction_hash: Signature,
         winner_bid_ids: Vec<entities::BidId>,
     ) -> anyhow::Result<entities::Auction> {
-        tracing::Span::current().record("auction_id", auction.id.to_string());
-        tracing::Span::current().record("tx_hash", format!("{:?}", transaction_hash));
-
         if let Some(mut updated_auction) =
             self.db.submit_auction(&auction, &transaction_hash).await?
         {

--- a/auction-server/src/auction/repository/update_in_memory_auction.rs
+++ b/auction-server/src/auction/repository/update_in_memory_auction.rs
@@ -4,9 +4,7 @@ use {
 };
 
 impl Repository {
-    #[tracing::instrument(skip_all, fields(auction_id))]
     pub async fn update_in_memory_auction(&self, auction: entities::Auction) {
-        tracing::Span::current().record("auction_id", auction.id.to_string());
         let mut write_guard = self.in_memory_store.auctions.write().await;
         match write_guard.get_mut(&auction.id) {
             Some(a) => {

--- a/auction-server/src/auction/service/cancel_bid.rs
+++ b/auction-server/src/auction/service/cancel_bid.rs
@@ -17,7 +17,6 @@ pub struct CancelBidInput {
 }
 
 impl Service {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     async fn cancel_bid_for_lock(
         &self,
         input: CancelBidInput,
@@ -71,7 +70,6 @@ impl Service {
         }
     }
 
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE), fields(bid_id = %input.bid_id))]
     pub async fn cancel_bid(&self, input: CancelBidInput) -> Result<(), RestError> {
         // Lock the bid to prevent submission
         let bid_lock = self

--- a/auction-server/src/auction/service/get_bid.rs
+++ b/auction-server/src/auction/service/get_bid.rs
@@ -11,7 +11,6 @@ pub struct GetBidInput {
 }
 
 impl Service {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     pub async fn get_bid(&self, input: GetBidInput) -> Result<entities::Bid, RestError> {
         self.repo.get_bid(input.bid_id).await
     }

--- a/auction-server/src/auction/service/get_bids.rs
+++ b/auction-server/src/auction/service/get_bids.rs
@@ -14,7 +14,6 @@ pub struct GetBidsInput {
 }
 
 impl Service {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     pub async fn get_bids(&self, input: GetBidsInput) -> Result<Vec<entities::Bid>, RestError> {
         self.repo.get_bids(input.profile.id, input.from_time).await
     }

--- a/auction-server/src/auction/service/optimize_bids.rs
+++ b/auction-server/src/auction/service/optimize_bids.rs
@@ -9,7 +9,6 @@ impl Service {
     /// considering the current state of the chain and the pending transactions.
     /// Right now, for simplicity, the method assume the bids are sorted, and tries to submit them in order
     /// and only return the ones that are successfully submitted.
-    #[tracing::instrument(skip_all)]
     pub async fn optimize_bids(&self, bids_sorted: &[Bid]) -> RpcResult<Vec<Bid>> {
         let simulator = &self.config.chain_config.simulator;
         simulator.optimize_bids(bids_sorted).await

--- a/auction-server/src/auction/service/submit_quote.rs
+++ b/auction-server/src/auction/service/submit_quote.rs
@@ -83,7 +83,6 @@ impl Service {
         Ok(bid.chain_data.transaction)
     }
 
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     async fn submit_auction_bid_for_lock(
         &self,
         signed_bid: entities::Bid,

--- a/auction-server/src/auction/service/update_bid_status.rs
+++ b/auction-server/src/auction/service/update_bid_status.rs
@@ -64,14 +64,10 @@ impl Service {
             })
     }
 
-    #[tracing::instrument(skip_all, fields(bid_id, status), err(level = tracing::Level::TRACE))]
     pub async fn update_bid_status(
         &self,
         mut input: UpdateBidStatusInput,
     ) -> Result<bool, RestError> {
-        tracing::Span::current().record("bid_id", input.bid.id.to_string());
-        tracing::Span::current().record("status", format!("{:?}", input.new_status));
-
         let (is_updated, conclusion_time_new) = self
             .repo
             .update_bid_status(input.bid.clone(), input.new_status.clone())

--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -1138,7 +1138,6 @@ impl Service {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     async fn verify_signatures(
         &self,
         bid: &entities::BidCreate,
@@ -1236,7 +1235,6 @@ impl Service {
         }
     }
 
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     pub async fn simulate_bid(&self, bid: &entities::BidCreate) -> Result<(), RestError> {
         const RETRY_LIMIT: usize = 5;
         const RETRY_DELAY: Duration = Duration::from_millis(100);

--- a/auction-server/src/opportunity/service/get_quote.rs
+++ b/auction-server/src/opportunity/service/get_quote.rs
@@ -181,7 +181,6 @@ fn get_fee_token(
 }
 
 impl Service {
-    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE))]
     async fn get_opportunity_create_for_quote(
         &self,
         quote_create: entities::QuoteCreate,


### PR DESCRIPTION
This PR scales down a bunch of the traces in the auction server. It leaves mostly those traces relating to external network calls, as well as the `get_quote` trace.