### PR TITLE
fix: ci anchor installation

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -36,6 +36,10 @@ jobs:
         name: Install pnpm
         with:
           run_install: true
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev pkg-config
       - name: Install Anchor CLI
         run: |
           cargo install --git https://github.com/coral-xyz/anchor avm


### PR DESCRIPTION
This PR fixes issues in the CI caused by the Github actions runners not having the `libudev` library installed.