### PR TITLE
Fix: delete pg auction

### DIFF
--- a/auction-server/clickhouse_migrations/0017_alter_bid_swap_tx_hash.sql
+++ b/auction-server/clickhouse_migrations/0017_alter_bid_swap_tx_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bid_swap ADD COLUMN tx_hash Nullable(String);

--- a/auction-server/clickhouse_migrations/0018_alter_opportunity_swap_tx_hash.sql
+++ b/auction-server/clickhouse_migrations/0018_alter_opportunity_swap_tx_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE opportunity_swap ADD COLUMN tx_hash Nullable(String);

--- a/auction-server/migrations/20250726182247_auction_creation_time_idx.down.sql
+++ b/auction-server/migrations/20250726182247_auction_creation_time_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS auction_creation_time_idx;

--- a/auction-server/migrations/20250726182247_auction_creation_time_idx.up.sql
+++ b/auction-server/migrations/20250726182247_auction_creation_time_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX auction_creation_time_idx ON auction (creation_time);

--- a/auction-server/src/auction/repository/add_bid_analytics.rs
+++ b/auction-server/src/auction/repository/add_bid_analytics.rs
@@ -37,6 +37,28 @@ impl Repository {
         decimals: HashMap<Pubkey, u8>,
     ) -> anyhow::Result<()> {
         let transaction = STANDARD.encode(bincode::serialize(&bid.chain_data.transaction.clone())?);
+        let tx_hash = match &bid.status {
+            entities::BidStatusSvm::Pending => None,
+            entities::BidStatusSvm::AwaitingSignature { auction } => {
+                Some(auction.tx_hash.to_string())
+            }
+            entities::BidStatusSvm::SentToUserForSubmission { auction } => {
+                Some(auction.tx_hash.to_string())
+            }
+            entities::BidStatusSvm::Submitted { auction } => Some(auction.tx_hash.to_string()),
+            entities::BidStatusSvm::Lost { auction } => {
+                auction.as_ref().map(|a| a.tx_hash.to_string())
+            }
+            entities::BidStatusSvm::Won { auction } => Some(auction.tx_hash.to_string()),
+            entities::BidStatusSvm::Failed { auction, reason: _ } => {
+                Some(auction.tx_hash.to_string())
+            }
+            entities::BidStatusSvm::Expired { auction } => Some(auction.tx_hash.to_string()),
+            entities::BidStatusSvm::Cancelled { auction } => Some(auction.tx_hash.to_string()),
+            entities::BidStatusSvm::SubmissionFailed { auction, reason: _ } => {
+                Some(auction.tx_hash.to_string())
+            }
+        };
         let bid_analytics = match data {
             entities::BidTransactionData::SubmitBid(transaction_data) => {
                 let SubmitBidArgs {
@@ -53,6 +75,7 @@ impl Repository {
                     bid_amount: bid.amount,
 
                     auction_id: bid.status.get_auction_id(),
+                    tx_hash,
                     submission_time: bid.submission_time,
                     conclusion_time: bid.conclusion_time,
 
@@ -113,6 +136,7 @@ impl Repository {
                     bid_amount: bid.amount,
 
                     auction_id: bid.status.get_auction_id(),
+                    tx_hash,
                     opportunity_id: bid.opportunity_id,
                     conclusion_time: bid.conclusion_time,
 

--- a/auction-server/src/auction/repository/models.rs
+++ b/auction-server/src/auction/repository/models.rs
@@ -858,6 +858,7 @@ pub struct BidAnalyticsSwap {
 
     #[serde(with = "clickhouse::serde::uuid::option")]
     pub auction_id:      Option<Uuid>,
+    pub tx_hash:         Option<String>,
     #[serde(with = "clickhouse::serde::time::datetime64::micros::option")]
     pub submission_time: Option<OffsetDateTime>,
     #[serde(with = "clickhouse::serde::uuid::option")]
@@ -905,6 +906,7 @@ pub struct BidAnalyticsLimo {
 
     #[serde(with = "clickhouse::serde::uuid::option")]
     pub auction_id:      Option<Uuid>,
+    pub tx_hash:         Option<String>,
     #[serde(with = "clickhouse::serde::time::datetime64::micros::option")]
     pub submission_time: Option<OffsetDateTime>,
     #[serde(with = "clickhouse::serde::time::datetime64::micros::option")]

--- a/auction-server/src/kernel/workers.rs
+++ b/auction-server/src/kernel/workers.rs
@@ -122,6 +122,12 @@ pub async fn run_delete_pg_db_history(
                         }
                     });
                     futures::future::try_join_all(futures).await?;
+
+                    delete_pg_db_auction_history(
+                        db,
+                        delete_threshold_secs,
+                    )
+                    .await?;
                 }
             }
         }
@@ -202,6 +208,38 @@ pub async fn delete_pg_db_opportunity_history(
         &[("chain_id", chain_id.to_string())]
     )
     .record(n_opportunities_deleted as f64);
+
+    Ok(())
+}
+
+#[instrument(
+    target = "metrics",
+    name = "db_delete_pg_auction_history"
+    fields(category = "db_queries", result = "success", name = "delete_pg_auction_history", tracing_enabled),
+    skip_all
+)]
+pub async fn delete_pg_db_auction_history(
+    db: &PgPool,
+    delete_threshold_secs: u64,
+) -> anyhow::Result<()> {
+    let threshold = OffsetDateTime::now_utc() - Duration::from_secs(delete_threshold_secs);
+    let n_auctions_deleted = sqlx::query!(
+        "WITH rows_to_delete AS (
+            SELECT id FROM auction WHERE creation_time < $1 LIMIT $2
+        ) DELETE FROM auction WHERE id IN (SELECT id FROM rows_to_delete)",
+        PrimitiveDateTime::new(threshold.date(), threshold.time()),
+        DELETE_BATCH_SIZE as i64,
+    )
+    .execute(db)
+    .await
+    .map_err(|e| {
+        tracing::Span::current().record("result", "error");
+        tracing::error!("Failed to delete PG DB auction history: {}", e);
+        e
+    })?
+    .rows_affected();
+
+    metrics::histogram!("db_delete_pg_auction_count").record(n_auctions_deleted as f64);
 
     Ok(())
 }


### PR DESCRIPTION
This PR addresses the growing size of the auction postgres table. In order to manage this, we can delete historical rows from the auction PG table similar to how we do for the bid and opportunity tables. This PR adds a `tx_hash` column to the analytics bid tables and inserts that value as part of the `add_bid_analytics` method. It also adds a deletion loop for the auction postgres table.