### PR TITLE
fix: add non-concurrent index creation migrations

### DIFF
--- a/auction-server/migrations/20250726182247_auction_creation_time_idx.up.sql
+++ b/auction-server/migrations/20250726182247_auction_creation_time_idx.up.sql
@@ -1,2 +1,1 @@
--- sqlx-no-transaction
-CREATE INDEX CONCURRENTLY auction_creation_time_idx ON auction (creation_time);
+CREATE INDEX auction_creation_time_idx ON auction (creation_time);

--- a/auction-server/migrations/20250730221458_idx_bid_auction_id.down.sql
+++ b/auction-server/migrations/20250730221458_idx_bid_auction_id.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_bid_auction_id;

--- a/auction-server/migrations/20250730221458_idx_bid_auction_id.up.sql
+++ b/auction-server/migrations/20250730221458_idx_bid_auction_id.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_bid_auction_id ON bid (auction_id);


### PR DESCRIPTION
This PR removes the `concurrently` from the migration query to add an index on `creation_time` to the postgres `auction` table. This is so that the migrations in `_sqlx_migrations` can remain consistent between local and the prod db. 

On local, we run this migration via the normal path since we aren't worried about downtime. However, on the prod db we had to run the migration manually in psql due to the risk of significant downtime from running this query (moreover, sqlx doesn't easily support running queries `concurrently`). 

In the prod version, we manually appended an entry to the `_sqlx_migrations` table with the checksum corresponding to the query file to indicate that the migration has taken place.


This PR also adds an index on the `auction_id` in the `bid` table; without this, the deletes cannot happen quickly due to the `ON DELETE RESTRICT` clause. Similar to above, the index was created concurrently, but the migration file shows a blocking index creation.