### PR TITLE
Fix: drop delete buffer auction secs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auction-server"
-version = "0.35.2"
+version = "0.36.0"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",

--- a/auction-server/Cargo.toml
+++ b/auction-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auction-server"
-version = "0.35.2"
+version = "0.36.0"
 edition = "2021"
 license-file = "license.txt"
 

--- a/auction-server/src/config.rs
+++ b/auction-server/src/config.rs
@@ -102,12 +102,6 @@ pub struct DeletePgRowsOptions {
     #[arg(env = "DELETE_THRESHOLD_SECONDS")]
     #[arg(default_value = "172800")] // 2 days in seconds
     pub delete_threshold_secs: u64,
-
-    /// The buffer time to account for bids that may still exist in the db. We cannot delete auctions with ids that are still referenced by bids, so we wait an additional buffer time before deleting auctions.
-    #[arg(long = "delete-buffer-auction-seconds")]
-    #[arg(env = "DELETE_BUFFER_AUCTION_SECONDS")]
-    #[arg(default_value = "3600")] // 1 hour in seconds
-    pub delete_buffer_auction_secs: u64,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/auction-server/src/kernel/workers.rs
+++ b/auction-server/src/kernel/workers.rs
@@ -125,7 +125,7 @@ pub async fn run_delete_pg_db_history(
 
                     delete_pg_db_auction_history(
                         db,
-                        delete_threshold_secs + delete_pg_rows_options.delete_buffer_auction_secs,
+                        delete_threshold_secs,
                     )
                     .await?;
                 }

--- a/integration.py
+++ b/integration.py
@@ -16,7 +16,6 @@ def main():
         f.write(f'export DELETE_ENABLED=true\n')
         f.write(f'export DELETE_INTERVAL_SECONDS={1}\n')
         f.write(f'export DELETE_THRESHOLD_SECONDS={60*60*24*2}\n')
-        f.write(f'export DELETE_BUFFER_AUCTION_SECONDS={60*60}\n')
 
     mint_buy = Keypair.from_json((open('keypairs/mint_buy.json').read())).pubkey()
     mint_sell = Keypair.from_json((open('keypairs/mint_sell.json').read())).pubkey()


### PR DESCRIPTION
This PR drops the `delete_buffer_auction_secs` param in the `DeletePgRowsOptions`, since `auction_id` no longer has the foreign key on delete constraint so we do not have to be as careful around deleting auctions. We can use the same parameters as for bid deletions.