### PR TITLE
feat(auction-server): add secp256k1_program to allowed programs

### DIFF
--- a/auction-server/src/auction/service/verification.rs
+++ b/auction-server/src/auction/service/verification.rs
@@ -51,6 +51,7 @@ use {
             InstructionError as SolanaInstructionError,
         },
         pubkey::Pubkey,
+        secp256k1_program,
         signature::Signature,
         signer::Signer as _,
         system_instruction::SystemInstruction,
@@ -305,6 +306,7 @@ impl Service {
         } else if *program_id == self.config.chain_config.express_relay.program_id
             || *program_id == spl_memo_client::ID
             || *program_id == compute_budget::id()
+            || *program_id == secp256k1_program::id()
         {
             Ok(())
         } else {


### PR DESCRIPTION
## Summary
Add Solana's native `secp256k1_program` (KeccakSecp256k1) to the program allowlist in bid verification.

## Problem
Searchers attempting to bid on Ondo assets receive:
```
Unsupported program KeccakSecp256k11111111111111111111111111111
```

This happens because Ondo's mint/redeem operations use the secp256k1 precompile for signature verification, which isn't in the current allowlist.

## Solution
Add `secp256k1_program::id()` to the allowed programs in `verification.rs`.

## Testing
- [ ] Existing tests pass
- [ ] Searchers can submit bids for Ondo assets

## Related
Reported by searcher integrating Ondo to Express Relay.